### PR TITLE
feat: add accordion content section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -1,3 +1,5 @@
 @use "scss";
 
 @use "../sections/content/intro/intro";
+
+@use "../sections/content/accordion/accordion";

--- a/template/sections/content/accordion/_accordion.scss
+++ b/template/sections/content/accordion/_accordion.scss
@@ -1,0 +1,53 @@
+// accordion section
+
+.accordion-button__arrow {
+        transition: transform 0.3s ease; /* Smooth rotation transition */
+}
+
+.accordion-button.active .accordion-button__arrow {
+        transform: rotate(-180deg); /* Rotate 90 degrees */
+}
+.accordion {
+        max-width: 600px;
+        margin: 20px auto;
+        border: 1px solid #ccc;
+        border-radius: 5px;
+        overflow: hidden;
+}
+
+.accordion-item {
+        border: 2px solid var(--c-primary-hover);
+        border-radius: var(--b-radius);
+}
+
+.accordion-button {
+        width: 100%;
+        padding: 10px;
+        text-align: left;
+        background-color: transparent;
+        border: none;
+        outline: none;
+        cursor: pointer;
+        font-size: 22px;
+        transition: background-color 0.3s;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+}
+
+.accordion-button:hover {
+        background-color: transparent;
+}
+
+.accordion-content {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease-out;
+        padding: 0 15px;
+        border-top: 1px solid var(--c-primary-hover);
+        font-size: 18px;
+}
+
+.accordion-content p {
+        margin: 15px 0;
+}

--- a/template/sections/content/accordion/accordion.html
+++ b/template/sections/content/accordion/accordion.html
@@ -1,0 +1,29 @@
+<div class="accordion">
+        {% for item in section.items %}
+        <div class="accordion-item">
+                <button class="accordion-button{% if item.active %} active{% endif %}">
+                        <div class="accordion-button__text">{{{item.title}}}</div>
+                        <div class="accordion-button__arrow">
+                                <svg
+                                        width="36"
+                                        height="36"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                >
+                                        <path
+                                                d="M6 9L12 15L18 9"
+                                                stroke="white"
+                                                stroke-width="2"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                        />
+                                </svg>
+                        </div>
+                </button>
+                <div class="accordion-content"{% if item.active %} style="max-height: fit-content"{% endif %}>
+                        {{{item.content}}}
+                </div>
+        </div>
+        {% endfor %}
+</div>

--- a/template/sections/content/accordion/readme.MD
+++ b/template/sections/content/accordion/readme.MD
@@ -1,0 +1,61 @@
+# 📂 Accordion `/sections/content/accordion`
+
+Accordion section for displaying collapsible content groups.
+
+## ✅ Features
+
+-   Multiple items with title and content
+-   Optional active state to pre-expand an item
+-   Arrow icon rotates on open
+-   Uses CSS variables for easy theming
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/content/accordion/accordion.html",
+        "items": [
+                { "title": "First item", "content": "<p>Item text</p>" },
+                { "title": "Second item", "content": "<p>Item text</p>", "active": true }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="accordion">
+        {% for item in section.items %}
+        <div class="accordion-item">
+                <button class="accordion-button{% if item.active %} active{% endif %}">
+                        <div class="accordion-button__text">{{{item.title}}}</div>
+                        <div class="accordion-button__arrow">...</div>
+                </button>
+                <div class="accordion-content"{% if item.active %} style="max-height: fit-content"{% endif %}>
+                        {{{item.content}}}
+                </div>
+        </div>
+        {% endfor %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Based on the `w-accardion` component styles
+-   Transitions animate arrow rotation and content reveal
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable            | Description                   |
+| ------------------- | ----------------------------- |
+| `--c-primary-hover` | Border and divider color      |
+| `--b-radius`        | Border radius for accordion   |
+```


### PR DESCRIPTION
## Summary
- add accordion section with reusable template and SCSS
- document accordion usage and data schema
- include accordion styles in main stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910d79a4f48333ac106c8ff8d193d1