### PR TITLE
feat: add callout box section

### DIFF
--- a/template/base.html
+++ b/template/base.html
@@ -61,14 +61,15 @@
 			  /* =======================
 			     🎨 Base Colors
 			  ======================= */
-			  --c-primary: {{{theme.colors.primary}}};             /* Main brand color */
-			  --c-secondary: {{{theme.colors.secondary}}};         /* Secondary UI color */
-			  --c-text-primary: {{{theme.colors.textPrimary}}};    /* Primary text color */
-			  --c-text-secondary: {{{theme.colors.textSecondary}}};/* Secondary text color */
-			  --c-body: {{{theme.colors.body}}};                   /* Background/body color */
-			  --c-bg-item: {{{theme.colors.bgItem}}};              /* Background of items/cards */
-			  --c-placeholder: {{{theme.colors.placeholder}}};     /* Placeholder/input hint color */
-			  --c-border: {{{theme.colors.border}}};               /* Default border color */
+                          --c-primary: {{{theme.colors.primary}}};             /* Main brand color */
+                          --c-secondary: {{{theme.colors.secondary}}};         /* Secondary UI color */
+                          --c-text-primary: {{{theme.colors.textPrimary}}};    /* Primary text color */
+                          --c-text-secondary: {{{theme.colors.textSecondary}}};/* Secondary text color */
+                          --c-text-body-secondary: {{{theme.colors.textBodySecondary}}};/* Body secondary text color */
+                          --c-body: {{{theme.colors.body}}};                   /* Background/body color */
+                          --c-bg-item: {{{theme.colors.bgItem}}};              /* Background of items/cards */
+                          --c-placeholder: {{{theme.colors.placeholder}}};     /* Placeholder/input hint color */
+                          --c-border: {{{theme.colors.border}}};               /* Default border color */
 
 			  /* =======================
 			     🎯 States & Feedback

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -3,3 +3,5 @@
 @use "../sections/content/intro/intro";
 
 @use "../sections/content/accordion/accordion";
+
+@use "../sections/content/callout-box/callout-box";

--- a/template/sections/content/callout-box/_callout-box.scss
+++ b/template/sections/content/callout-box/_callout-box.scss
@@ -1,0 +1,48 @@
+// callout-box section
+
+.callout-box {
+        padding: calc(20px * var(--padding-scale));
+        background-color: var(--c-bg-item);
+        border-left: 4px solid var(--c-primary-border);
+        border-radius: var(--b-radius);
+        color: var(--c-text-primary);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 24px;
+                font-weight: 600;
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                margin-bottom: calc(8px * var(--margin-scale));
+        }
+
+        &__description {
+                font-family: var(--ff-base);
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .callout-box {
+                &__title {
+                        font-size: 20px;
+                }
+                &__description {
+                        font-size: calc(var(--font-size) * 0.9);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .callout-box {
+                &__title {
+                        font-size: 18px;
+                }
+                &__description {
+                        font-size: calc(var(--font-size) * 0.875);
+                }
+        }
+}

--- a/template/sections/content/callout-box/callout-box.html
+++ b/template/sections/content/callout-box/callout-box.html
@@ -1,0 +1,8 @@
+<div class="callout-box">
+        {% if section.title %}
+        <div class="callout-box__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="callout-box__description">{{{section.description}}}</div>
+        {% endif %}
+</div>

--- a/template/sections/content/callout-box/readme.MD
+++ b/template/sections/content/callout-box/readme.MD
@@ -1,0 +1,69 @@
+# 📂 Callout Box `/sections/content/callout-box`
+
+A simple highlighted block for drawing attention to important information.
+Supports an optional title and description, styled using global theme tokens.
+
+## ✅ Features
+
+-   Optional title and description (conditionally rendered)
+-   Left-accent border to emphasize content
+-   Responsive typography across breakpoints
+-   Uses CSS variables for colors, fonts, spacing, and responsiveness
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/content/callout-box/callout-box.html",
+        "title": "Optional callout title",
+        "description": "Important information or message"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="callout-box">
+        {% if section.title %}
+        <div class="callout-box__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="callout-box__description">{{{section.description}}}</div>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Accent border and background colors are controlled via CSS variables
+-   Spacing scales with `--padding-scale` and `--margin-scale`
+-   Typography inherits from global font and sizing variables
+-   Breakpoints adjust font sizes for smaller screens
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                        |
+| ------------------------------- | -------------------------------------------------- |
+| `--padding-scale`               | Scales inner padding                               |
+| `--margin-scale`                | Controls margin spacing for title                  |
+| `--font-size`                   | Base font size for description                     |
+| `--line-height`                 | Line height for title and description              |
+| `--letter-spacing`              | Letter spacing for text                            |
+| `--b-radius`                    | Rounds container corners                           |
+| `--ff-base`                     | Font for description text                          |
+| `--ff-title`                    | Font for title text                                |
+| `--c-bg-item`                   | Background color of the callout box                |
+| `--c-primary-border`            | Color of the left accent border                    |
+| `--c-text-primary`              | Title text color                                   |
+| `--c-text-body-secondary`       | Description text color                             |
+| `--bp-md`, `--bp-sm`            | Used in media queries to adjust sizes responsively |
+
+---


### PR DESCRIPTION
## Summary
- add callout box section with responsive styles and docs
- expose text body secondary color variable in base template
- wire callout box styles into global stylesheet

## Testing
- `npm test` *(fails: jest not found)*
- `npm install jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891151e93308333ac2989eb094316ec