### PR TITLE
feat: add code-block section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -3,3 +3,5 @@
 @use "../sections/content/intro/intro";
 
 @use "../sections/content/accordion/accordion";
+
+@use "../sections/content/code-block/code-block";

--- a/template/sections/content/code-block/_code-block.scss
+++ b/template/sections/content/code-block/_code-block.scss
@@ -1,0 +1,45 @@
+// code-block section
+
+.code-block {
+        padding: calc(20px * var(--padding-scale));
+        background-color: var(--c-bg-item);
+        border-radius: var(--b-radius);
+        color: var(--c-text-primary);
+        font-family: var(--ff-base);
+}
+
+.code-block__title {
+        font-family: var(--ff-title);
+        font-size: calc(var(--font-size) * 1.5);
+        line-height: var(--line-height);
+        margin-bottom: calc(12px * var(--margin-scale));
+        color: var(--c-text-primary);
+}
+
+.code-block__code {
+        background-color: var(--c-dark);
+        padding: calc(16px * var(--padding-scale));
+        border-radius: var(--b-radius);
+        overflow-x: auto;
+        font-family: var(--ff-second);
+        font-size: calc(var(--font-size) * 0.875);
+        line-height: var(--line-height);
+        color: var(--c-text-secondary);
+        transition: color var(--transition);
+}
+
+.code-block__code:hover {
+        color: var(--c-code-hover);
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .code-block__title {
+                font-size: calc(var(--font-size) * 1.25);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .code-block__title {
+                font-size: calc(var(--font-size) * 1.125);
+        }
+}

--- a/template/sections/content/code-block/code-block.html
+++ b/template/sections/content/code-block/code-block.html
@@ -1,0 +1,8 @@
+<div class="code-block">
+        {% if section.title %}
+        <div class="code-block__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.code %}
+        <pre class="code-block__code"><code>{{{section.code}}}</code></pre>
+        {% endif %}
+</div>

--- a/template/sections/content/code-block/readme.MD
+++ b/template/sections/content/code-block/readme.MD
@@ -1,0 +1,59 @@
+# 📂 Code Block `/sections/content/code-block`
+
+Reusable block for rendering formatted code snippets. Supports an optional title and adapts to global theme variables.
+
+## ✅ Features
+
+-   Optional title element
+-   Preformatted code area with horizontal scrolling
+-   Colors, fonts and spacing driven by CSS variables
+-   Responsive font sizing at breakpoints
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/content/code-block/code-block.html",
+        "title": "Optional section title",
+        "code": "console.log('Hello, world!');"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="code-block">
+        {% if section.title %}
+        <div class="code-block__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.code %}
+        <pre class="code-block__code"><code>{{{section.code}}}</code></pre>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                 | Description                          |
+| ------------------------ | ------------------------------------ |
+| `--padding-scale`        | Scales the block padding              |
+| `--margin-scale`         | Controls spacing below the title      |
+| `--b-radius`             | Rounds block and code container       |
+| `--font-size`            | Base font size for title and code     |
+| `--line-height`          | Line height for text and code         |
+| `--ff-base`              | Font family for body text             |
+| `--ff-title`             | Font family for title text            |
+| `--ff-second`            | Font family for code                  |
+| `--c-bg-item`            | Background color of the block         |
+| `--c-dark`               | Background color of the code area     |
+| `--c-text-primary`       | Color of title text                   |
+| `--c-text-secondary`     | Color of code text                    |
+| `--c-code-hover`         | Code text color on hover              |
+| `--transition`           | Transition for color hover effect     |
+| `--bp-md`, `--bp-sm`     | Breakpoints for responsive sizing     |
+
+---


### PR DESCRIPTION
## Summary
- add code-block section with HTML template, SCSS styles and docs
- hook new section styles into global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689115a7a96c83339d8dc1955a34ae86