### PR TITLE
feat: add hero section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -1,4 +1,5 @@
 @use "scss";
+@use "../sections/content/hero/hero";
 
 @use "../sections/content/intro/intro";
 @use "../sections/content/feature-list/feature-list";

--- a/template/sections/content/hero/_hero.scss
+++ b/template/sections/content/hero/_hero.scss
@@ -1,0 +1,101 @@
+// hero section
+
+.hero {
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+
+        &__wrapper {
+                display: flex;
+                flex-flow: row wrap;
+                align-items: center;
+        }
+
+        &__text {
+                flex: 1 0;
+                padding-right: calc(230px * var(--padding-scale));
+        }
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 38px;
+                font-weight: 700;
+                padding-bottom: calc(30px * var(--padding-scale));
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                max-width: 70ch;
+        }
+
+        &__imgs {
+                flex: 0 0 calc(300px * var(--padding-scale));
+                position: relative;
+
+                img {
+                        width: 100%;
+                        display: block;
+                }
+        }
+
+        &__img {
+                max-width: calc(100px * var(--padding-scale));
+                width: 100%;
+                bottom: 0;
+                position: absolute;
+
+                &--first {
+                        left: 0;
+                }
+
+                &--second {
+                        right: 0;
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .hero__text {
+                padding-right: calc(100px * var(--padding-scale));
+        }
+        .hero__title {
+                font-size: 28px;
+                padding-bottom: calc(20px * var(--padding-scale));
+        }
+        .hero__imgs {
+                flex: 0 0 calc(260px * var(--padding-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .hero__wrapper {
+                flex-flow: column wrap;
+                align-items: unset;
+        }
+        .hero__imgs {
+                flex: 0 0 100%;
+                max-width: calc(290px * var(--padding-scale));
+                width: 100%;
+        }
+        .hero__text {
+                padding-right: calc(20px * var(--padding-scale));
+                margin-bottom: calc(20px * var(--margin-scale));
+        }
+        .hero__title {
+                font-size: 24px;
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .hero__title {
+                font-size: 20px;
+        }
+        .hero__description {
+                font-size: calc(var(--font-size) * 0.875);
+        }
+}

--- a/template/sections/content/hero/hero.html
+++ b/template/sections/content/hero/hero.html
@@ -1,0 +1,29 @@
+<div class="hero">
+        <div class="hero__wrapper">
+                <div class="hero__text">
+                        {% if section.title %}
+                        <div class="hero__title">{{{section.title}}}</div>
+                        {% endif %}
+                        {% if section.description %}
+                        <div class="hero__description">{{{section.description}}}</div>
+                        {% endif %}
+                </div>
+                {% if section.img %}
+                <div class="hero__imgs">
+                        <img src="{{{section.img}}}" alt="" />
+                        {% if section.imgs %}
+                        {% if section.imgs[1] %}
+                        <div class="hero__img hero__img--first">
+                                <img src="{{{section.imgs[1]}}}" alt="" />
+                        </div>
+                        {% endif %}
+                        {% if section.imgs[0] %}
+                        <div class="hero__img hero__img--second">
+                                <img src="{{{section.imgs[0]}}}" alt="" />
+                        </div>
+                        {% endif %}
+                        {% endif %}
+                </div>
+                {% endif %}
+        </div>
+</div>

--- a/template/sections/content/hero/readme.MD
+++ b/template/sections/content/hero/readme.MD
@@ -1,0 +1,89 @@
+# 📂 Hero `/sections/content/hero`
+
+Hero section with prominent title, description, and imagery. Supports a main image and optional decorative images.
+
+## ✅ Features
+
+-   Optional title and description
+-   Supports main image plus up to two overlay images
+-   Responsive layout with flexbox
+-   Uses CSS variables for colors, fonts, spacing, and breakpoints
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/content/hero/hero.html",
+        "title": "Hero title",
+        "description": "Optional descriptive text",
+        "img": "/img/hero-main.png",
+        "imgs": ["/img/hero-second.png", "/img/hero-first.png"]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="hero">
+        <div class="hero__wrapper">
+                <div class="hero__text">
+                        {% if section.title %}
+                        <div class="hero__title">{{{section.title}}}</div>
+                        {% endif %}
+                        {% if section.description %}
+                        <div class="hero__description">{{{section.description}}}</div>
+                        {% endif %}
+                </div>
+                {% if section.img %}
+                <div class="hero__imgs">
+                        <img src="{{{section.img}}}" alt="" />
+                        {% if section.imgs %}
+                        {% if section.imgs[1] %}
+                        <div class="hero__img hero__img--first">
+                                <img src="{{{section.imgs[1]}}}" alt="" />
+                        </div>
+                        {% endif %}
+                        {% if section.imgs[0] %}
+                        <div class="hero__img hero__img--second">
+                                <img src="{{{section.imgs[0]}}}" alt="" />
+                        </div>
+                        {% endif %}
+                        {% endif %}
+                </div>
+                {% endif %}
+        </div>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses `calc(... * var(--padding-scale))` and `--margin-scale` for scalable spacing
+-   Breakpoints leverage `--bp-lg`, `--bp-md`, and `--bp-sm`
+-   Typography uses `--ff-title`, `--ff-base`, `--font-size`, and related variables
+-   Colors derive from `--c-text-primary` and `--c-text-body-secondary`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                        |
+| ------------------------------- | -------------------------------------------------- |
+| `--padding-scale`               | Scales padding values in section                   |
+| `--margin-scale`                | Controls margin spacing                            |
+| `--font-size`                   | Base font size for description                     |
+| `--line-height`                 | Line height for title and description              |
+| `--letter-spacing`              | Applied to title and description                   |
+| `--b-radius`                    | (not used) available for image rounding            |
+| `--ff-base`                     | Font for description text                          |
+| `--ff-title`                    | Font for title text                                |
+| `--c-text-primary`              | Title text color                                   |
+| `--c-text-body-secondary`       | Description text color                             |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Used in media queries to adjust sizes responsively |
+
+---


### PR DESCRIPTION
## Summary
- add hero section with optional images and text
- document hero component and theme variables
- wire hero styles into main stylesheet

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68911aef746083339720bab871c4b8ff