### PR TITLE
feat(blog): add categories section [skip ci]

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -1,4 +1,5 @@
 @use "scss";
+@use "../sections/blog/categories/categories";
 @use "../sections/content/text-block/text-block";
 @use "../sections/content/testimonial/testimonial";
 @use "../sections/content/statistics/statistics";

--- a/template/sections/blog/categories/_categories.scss
+++ b/template/sections/blog/categories/_categories.scss
@@ -1,0 +1,84 @@
+// categories section
+
+.categories {
+        font-family: var(--ff-base);
+        text-align: center;
+        padding-bottom: calc(50px * var(--padding-scale));
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                margin-top: calc(12px * var(--margin-scale));
+                max-width: 70ch;
+                margin-left: auto;
+                margin-right: auto;
+                transition: color var(--transition);
+        }
+
+        &__list {
+                list-style: none;
+                margin: calc(24px * var(--margin-scale)) 0 0;
+                padding: 0;
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: calc(12px * var(--margin-scale));
+        }
+
+        &__item {
+                background-color: var(--c-bg-item);
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                transition: background-color var(--transition),
+                        border-color var(--transition);
+        }
+
+        &__link {
+                display: block;
+                padding: calc(8px * var(--padding-scale))
+                        calc(16px * var(--padding-scale));
+                color: var(--c-text-primary);
+                text-decoration: none;
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                transition: color var(--transition);
+        }
+
+        &__item:hover {
+                background-color: var(--c-primary-hover);
+                border-color: var(--c-primary-border);
+                .categories__link {
+                        color: var(--c-text-secondary);
+                }
+        }
+
+        &__count {
+                margin-left: calc(4px * var(--margin-scale));
+                color: var(--c-text-body-secondary);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .categories__title {
+                font-size: 24px;
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .categories__title {
+                font-size: 20px;
+        }
+}

--- a/template/sections/blog/categories/categories.html
+++ b/template/sections/blog/categories/categories.html
@@ -1,0 +1,29 @@
+<div class="categories">
+        {% if section.title %}
+        <div class="categories__title">{{{section.title}}}</div>
+        {% endif %} {% if section.description %}
+        <div class="categories__description">{{{section.description}}}</div>
+        {% endif %} {% if section.categories %}
+        <ul class="categories__list">
+                {% for category in section.categories %}
+                <li class="categories__item">
+                        {% if category.url %}
+                        <a href="{{{category.url}}}" class="categories__link">
+                                {{{category.title}}}
+                                {% if category.count %}
+                                <span class="categories__count">{{{category.count}}}</span>
+                                {% endif %}
+                        </a>
+                        {% else %}
+                        <span class="categories__link">
+                                {{{category.title}}}
+                                {% if category.count %}
+                                <span class="categories__count">{{{category.count}}}</span>
+                                {% endif %}
+                        </span>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>

--- a/template/sections/blog/categories/readme.MD
+++ b/template/sections/blog/categories/readme.MD
@@ -1,0 +1,87 @@
+# 🏷️ Categories `/sections/blog/categories`
+
+Section for displaying a list of blog categories as links with optional counts. Useful for blog sidebars or indexes.
+
+## ✅ Features
+
+- Optional title and description
+- List of categories rendered dynamically
+- Each category can have a URL and optional post count
+- Responsive styling using global design tokens
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/blog/categories/categories.html",
+        "title": "Browse by category",
+        "description": "Optional helper text",
+        "categories": [
+                { "title": "News", "url": "/blog/news", "count": 3 },
+                { "title": "Events", "url": "/blog/events" },
+                { "title": "Tutorials", "url": "/blog/tutorials", "count": 12 }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="categories">
+        {% if section.title %}
+        <div class="categories__title">{{{section.title}}}</div>
+        {% endif %} {% if section.description %}
+        <div class="categories__description">{{{section.description}}}</div>
+        {% endif %} {% if section.categories %}
+        <ul class="categories__list">
+                {% for category in section.categories %}
+                <li class="categories__item">
+                        {% if category.url %}
+                        <a href="{{{category.url}}}" class="categories__link">
+                                {{{category.title}}}
+                                {% if category.count %}
+                                <span class="categories__count">{{{category.count}}}</span>
+                                {% endif %}
+                        </a>
+                        {% else %}
+                        <span class="categories__link">
+                                {{{category.title}}}
+                                {% if category.count %}
+                                <span class="categories__count">{{{category.count}}}</span>
+                                {% endif %}
+                        </span>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Theme Variables Used
+
+| Variable                  | Description                          |
+| ------------------------- | ------------------------------------ |
+| `--ff-base`               | Base font family                     |
+| `--ff-title`              | Font family for section title        |
+| `--font-size`             | Base font size for links             |
+| `--line-height`           | Line height for text                 |
+| `--letter-spacing`        | Letter spacing for text              |
+| `--padding-scale`         | Scales padding values                |
+| `--margin-scale`          | Scales margin values                 |
+| `--b-radius`              | Border radius for items              |
+| `--c-bg-item`             | Background color of category pills   |
+| `--c-border`              | Border color of category pills       |
+| `--c-primary-hover`       | Hover background color               |
+| `--c-primary-border`      | Hover border color                   |
+| `--c-text-primary`        | Text color for title and links       |
+| `--c-text-secondary`      | Text color on hover                  |
+| `--c-text-body-secondary` | Text color for description and count |
+| `--transition`            | Transition timing function           |
+| `--bp-md`, `--bp-sm`      | Breakpoints for responsive titles    |
+
+---


### PR DESCRIPTION
## Summary
- add blog categories section with dynamic category links
- style categories with global CSS variables and responsive layout
- document category section usage and theme tokens

## Testing
- `npx sass template/css/index.scss >/tmp/index.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6893b81bf5dc8333abdd0bc71f4e904a