### PR TITLE
feat: add blog meta section [skip ci]

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -1,4 +1,5 @@
 @use "scss";
+@use "../sections/blog/meta/meta";
 @use "../sections/content/text-block/text-block";
 @use "../sections/content/testimonial/testimonial";
 @use "../sections/content/statistics/statistics";

--- a/template/sections/blog/meta/_meta.scss
+++ b/template/sections/blog/meta/_meta.scss
@@ -1,0 +1,39 @@
+// blog meta section
+
+.blog-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: calc(8px * var(--margin-scale));
+        font-family: var(--ff-base);
+        font-size: calc(var(--font-size) * 0.875);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-secondary);
+
+        &__item {
+                display: flex;
+                align-items: center;
+
+                a {
+                        color: var(--c-primary);
+                        text-decoration: none;
+                        transition: color var(--transition);
+
+                        &:hover {
+                                color: var(--c-primary-hover);
+                        }
+                }
+        }
+
+        &__item:not(:last-child)::after {
+                content: "\2022";
+                margin: 0 calc(8px * var(--margin-scale));
+                color: var(--c-text-secondary);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .blog-meta {
+                font-size: calc(var(--font-size) * 0.75);
+        }
+}

--- a/template/sections/blog/meta/meta.html
+++ b/template/sections/blog/meta/meta.html
@@ -1,0 +1,20 @@
+<div class="blog-meta">
+        {% if section.date %}
+        <div class="blog-meta__item blog-meta__date">
+                <time datetime="{{{section.date}}}">{{{section.date}}}</time>
+        </div>
+        {% endif %}
+        {% if section.author %}
+        <div class="blog-meta__item blog-meta__author">{{{section.author}}}</div>
+        {% endif %}
+        {% if section.readTime %}
+        <div class="blog-meta__item blog-meta__read-time">{{{section.readTime}}}</div>
+        {% endif %}
+        {% if section.categories %}
+        <div class="blog-meta__item blog-meta__categories">
+                {% for category in section.categories %}
+                <a href="{{{category.url}}}">{{{category.name}}}</a>{% if not loop.last %}, {% endif %}
+                {% endfor %}
+        </div>
+        {% endif %}
+</div>

--- a/template/sections/blog/meta/readme.MD
+++ b/template/sections/blog/meta/readme.MD
@@ -1,0 +1,76 @@
+# 📂 Meta `/sections/blog/meta`
+
+Blog post metadata such as publication date, author, reading time, and categories.
+
+## ✅ Features
+
+-   Optional date, author, reading time, and category list
+-   Items separated by bullets and responsive
+-   Uses CSS variables for colors, fonts, spacing, and responsiveness
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/blog/meta/meta.html",
+        "date": "2024-05-01",
+        "author": "John Doe",
+        "readTime": "5 min read",
+        "categories": [
+                { "name": "Tech", "url": "/category/tech" },
+                { "name": "AI", "url": "/category/ai" }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="blog-meta">
+        {% if section.date %}
+        <div class="blog-meta__item blog-meta__date">
+                <time datetime="{{{section.date}}}">{{{section.date}}}</time>
+        </div>
+        {% endif %}
+        {% if section.author %}
+        <div class="blog-meta__item blog-meta__author">{{{section.author}}}</div>
+        {% endif %}
+        {% if section.readTime %}
+        <div class="blog-meta__item blog-meta__read-time">{{{section.readTime}}}</div>
+        {% endif %}
+        {% if section.categories %}
+        <div class="blog-meta__item blog-meta__categories">
+                {% for category in section.categories %}
+                <a href="{{{category.url}}}">{{{category.name}}}</a>{% if not loop.last %}, {% endif %}
+                {% endfor %}
+        </div>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses `flex` layout with `gap` for spacing
+-   Bullet separators added via pseudo-element
+-   Font sizing adapts via `--font-size` and `--bp-sm`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable              | Description                                  |
+| --------------------- | -------------------------------------------- |
+| `--margin-scale`      | Spacing between meta items                   |
+| `--ff-base`           | Base font family                             |
+| `--font-size`         | Base font size for text                      |
+| `--line-height`       | Line height                                  |
+| `--letter-spacing`    | Letter spacing                               |
+| `--c-text-secondary`  | Meta text color                              |
+| `--c-primary`         | Link color                                   |
+| `--c-primary-hover`   | Link hover color                             |
+| `--transition`        | Transition for link hover                    |
+| `--bp-sm`             | Breakpoint for small devices                 |


### PR DESCRIPTION
## Summary
- add blog meta section with optional date, author, reading time, and categories
- document usage and styling variables
- wire meta styles into global SCSS bundle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b82bd97c8333b6c309a264e3713f