### PR TITLE
feat: add business map section [skip ci]

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -19,3 +19,4 @@
 @use "../sections/content/accordion/accordion";
 @use "../sections/content/code-block/code-block";
 @use "../sections/content/callout-box/callout-box";
+@use "../sections/business/map/map";

--- a/template/sections/business/map/_map.scss
+++ b/template/sections/business/map/_map.scss
@@ -1,0 +1,67 @@
+// map section
+
+.map {
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+        text-align: center;
+
+        &__container {
+                width: 100%;
+                height: calc(400px * var(--padding-scale));
+                border-radius: var(--b-radius);
+                overflow: hidden;
+        }
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                text-transform: uppercase;
+                padding-top: calc(20px * var(--padding-scale));
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                max-width: 70ch;
+                margin: calc(12px * var(--margin-scale)) auto 0;
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .map__title {
+                font-size: 28px;
+        }
+        .map__container {
+                height: calc(350px * var(--padding-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .map__title {
+                font-size: 24px;
+        }
+        .map__container {
+                height: calc(300px * var(--padding-scale));
+        }
+        .map__description {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .map__title {
+                font-size: 20px;
+        }
+        .map__container {
+                height: calc(250px * var(--padding-scale));
+        }
+        .map__description {
+                font-size: calc(var(--font-size) * 0.875);
+        }
+}

--- a/template/sections/business/map/map.html
+++ b/template/sections/business/map/map.html
@@ -1,0 +1,21 @@
+<div class="map">
+        <div id="map" class="map__container"></div>
+
+        {% if section.title %}
+        <div class="map__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="map__description">{{{section.description}}}</div>
+        {% endif %}
+</div>
+<script>
+        function initMap() {
+                const position = { lat: {{{section.lat}}}, lng: {{{section.lng}}} };
+                const map = new google.maps.Map(document.getElementById('map'), {
+                        zoom: {{{section.zoom}}},
+                        center: position,
+                });
+                new google.maps.Marker({ position, map });
+        }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{{section.apiKey}}}&callback=initMap" async defer></script>

--- a/template/sections/business/map/readme.MD
+++ b/template/sections/business/map/readme.MD
@@ -1,0 +1,85 @@
+# 🗺️ Map `/sections/business/map`
+
+Interactive map section that embeds a Google Map with a marker.
+Optional title and description allow contextual messaging above the map.
+
+## ✅ Features
+
+-   Renders a Google Map centered on provided coordinates
+-   Single marker highlighting the location
+-   Optional title and description
+-   Responsive height adjustments across breakpoints
+-   Uses CSS variables for spacing, typography and colors
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/business/map/map.html",
+        "lat": 50.4501,
+        "lng": 30.5234,
+        "zoom": 14,
+        "apiKey": "GOOGLE_MAPS_API_KEY",
+        "title": "Our Location",
+        "description": "Find us on the map"
+}
+```
+
+---
+
+## 🧱 HTML Structure
+
+```html
+<div class="map">
+        <div id="map" class="map__container"></div>
+
+        {% if section.title %}
+        <div class="map__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="map__description">{{{section.description}}}</div>
+        {% endif %}
+</div>
+<script>
+        function initMap() {
+                const position = { lat: {{{section.lat}}}, lng: {{{section.lng}}} };
+                const map = new google.maps.Map(document.getElementById('map'), {
+                        zoom: {{{section.zoom}}},
+                        center: position,
+                });
+                new google.maps.Marker({ position, map });
+        }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{{section.apiKey}}}&callback=initMap" async defer></script>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Map container uses `calc(... * var(--padding-scale))` for scalable height
+-   Typography and spacing adapt via `--font-size`, `--line-height`, `--letter-spacing`, and `--margin-scale`
+-   Title and description colors driven by `--c-text-primary` and `--c-text-body-secondary`
+-   Responsive sizing controlled by `--bp-lg`, `--bp-md`, and `--bp-sm`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| -------- | ----------- |
+| `--padding-scale` | Scales section padding and map height |
+| `--margin-scale` | Controls spacing above/below text |
+| `--font-size` | Base font size for description |
+| `--line-height` | Line height for text elements |
+| `--letter-spacing` | Letter spacing for title/description |
+| `--b-radius` | Rounds the map container corners |
+| `--ff-base` | Font for description text |
+| `--ff-title` | Font for title text |
+| `--c-text-primary` | Title text color |
+| `--c-text-body-secondary` | Description text color |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Breakpoints for responsive adjustments |
+
+---


### PR DESCRIPTION
## Summary
- add interactive business map section with Google Maps integration
- document map section usage and styling variables
- include map styles in global stylesheet

## Testing
- `npx sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6893c02f7a4083339dd528228f243994