### PR TITLE
feat: add partners business section [skip ci]

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -19,3 +19,4 @@
 @use "../sections/content/accordion/accordion";
 @use "../sections/content/code-block/code-block";
 @use "../sections/content/callout-box/callout-box";
+@use "../sections/business/partners/partners";

--- a/template/sections/business/partners/_partners.scss
+++ b/template/sections/business/partners/_partners.scss
@@ -1,0 +1,71 @@
+// partners section
+
+.partners {
+        padding: calc(40px * var(--padding-scale)) 0;
+        text-align: center;
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 36px;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+                margin-bottom: calc(24px * var(--margin-scale));
+        }
+
+        &__items {
+                list-style: none;
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: calc(30px * var(--margin-scale));
+                padding: 0;
+                margin: 0;
+        }
+
+        &__item {
+                flex: 0 1 calc(25% - (30px * var(--margin-scale)));
+                max-width: 200px;
+                padding: calc(10px * var(--padding-scale));
+                background-color: var(--c-bg-item);
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                transition: border-color var(--transition), background-color var(--transition);
+
+                img {
+                        max-width: 100%;
+                        max-height: 60px;
+                        width: auto;
+                        height: auto;
+                        display: block;
+                }
+
+                &:hover {
+                        border-color: var(--c-primary-border);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .partners__item {
+                flex: 0 1 calc(33.333% - (20px * var(--margin-scale)));
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .partners__item {
+                flex: 0 1 calc(50% - (20px * var(--margin-scale)));
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .partners__item {
+                flex: 0 1 calc(100% - (10px * var(--margin-scale)));
+        }
+}

--- a/template/sections/business/partners/partners.html
+++ b/template/sections/business/partners/partners.html
@@ -1,0 +1,19 @@
+<div class="partners">
+        {% if section.title %}
+        <div class="partners__title">{{{section.title}}}</div>
+        {% endif %} {% if section.items %}
+        <ul class="partners__items">
+                {% for item in section.items %}
+                <li class="partners__item">
+                        {% if item.url %}
+                        <a href="{{{item.url}}}" target="_blank" rel="noopener">
+                                <img src="{{{item.img}}}" alt="{{{item.alt}}}" />
+                        </a>
+                        {% else %}
+                        <img src="{{{item.img}}}" alt="{{{item.alt}}}" />
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>

--- a/template/sections/business/partners/readme.MD
+++ b/template/sections/business/partners/readme.MD
@@ -1,0 +1,69 @@
+# 📂 Partners `/sections/business/partners`
+
+Display a responsive grid of partner logos with an optional title.
+
+## ✅ Features
+
+- Optional title
+- Grid of partner logos with optional links
+- Responsive layout using flexbox
+- Themed via CSS variables
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+  "src": "/sections/business/partners/partners.html",
+  "title": "Our Partners",
+  "items": [
+    { "img": "/img/partner1.svg", "alt": "Partner 1", "url": "https://partner1.com" },
+    { "img": "/img/partner2.svg", "alt": "Partner 2" }
+  ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="partners">
+        {% if section.title %}
+        <div class="partners__title">{{{section.title}}}</div>
+        {% endif %} {% if section.items %}
+        <ul class="partners__items">
+                {% for item in section.items %}
+                <li class="partners__item">
+                        {% if item.url %}
+                        <a href="{{{item.url}}}" target="_blank" rel="noopener">
+                                <img src="{{{item.img}}}" alt="{{{item.alt}}}" />
+                        </a>
+                        {% else %}
+                        <img src="{{{item.img}}}" alt="{{{item.alt}}}" />
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| --- | --- |
+| `--ff-base` | Base font for section |
+| `--ff-title` | Font for the optional title |
+| `--padding-scale` | Scales section padding |
+| `--margin-scale` | Controls spacing between items |
+| `--letter-spacing` | Applied to title |
+| `--line-height` | Applied to title |
+| `--c-text-primary` | Title color |
+| `--c-bg-item` | Background color for partner items |
+| `--c-border` | Default border color |
+| `--c-primary-border` | Hover border color |
+| `--b-radius` | Item border radius |
+| `--transition` | Hover transition |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Responsive breakpoints |


### PR DESCRIPTION
## Summary
- add business partners section with optional title and grid of partner logos
- style partners section with theme variables and responsive layout
- document partners section and register its styles

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_6893c053e3ac83339be15e043b54ec25