### PR TITLE
feat: add CTA banner section [skip ci]

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -28,3 +28,4 @@
 @use "../sections/business/map/map";
 @use "../sections/business/milestones/milestones";
 @use "../sections/business/partners/partners";
+@use "../sections/cta/banner/banner";

--- a/template/sections/cta/banner/_banner.scss
+++ b/template/sections/cta/banner/_banner.scss
@@ -1,0 +1,69 @@
+// banner section
+
+.banner {
+        padding: calc(40px * var(--padding-scale));
+        text-align: center;
+        background-color: var(--c-primary);
+        border-radius: var(--b-radius);
+        color: var(--c-text-primary);
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                margin-bottom: calc(12px * var(--margin-scale));
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-primary);
+                margin-bottom: calc(20px * var(--margin-scale));
+                max-width: 70ch;
+                margin-left: auto;
+                margin-right: auto;
+        }
+
+        &__action {
+                margin-top: calc(20px * var(--margin-scale));
+        }
+
+        &__button {
+                display: inline-block;
+                padding: calc(10px * var(--padding-scale)) calc(20px * var(--padding-scale));
+                font-size: var(--font-size);
+                font-family: var(--ff-base);
+                background-color: var(--c-secondary);
+                color: var(--c-text-primary);
+                text-decoration: none;
+                border-radius: var(--b-radius);
+                transition: background-color var(--transition);
+
+                &:hover {
+                        background-color: var(--c-primary-hover);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .banner {
+                padding: calc(30px * var(--padding-scale));
+        }
+        .banner__title {
+                font-size: 24px;
+        }
+        .banner__button {
+                padding: calc(8px * var(--padding-scale)) calc(16px * var(--padding-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .banner__title {
+                font-size: 20px;
+        }
+}

--- a/template/sections/cta/banner/banner.html
+++ b/template/sections/cta/banner/banner.html
@@ -1,0 +1,13 @@
+<div class="banner">
+        {% if section.title %}
+        <div class="banner__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="banner__description">{{{section.description}}}</div>
+        {% endif %}
+        {% if section.button %}
+        <div class="banner__action">
+                <a href="{{{section.button.url}}}" class="banner__button">{{{section.button.label}}}</a>
+        </div>
+        {% endif %}
+</div>

--- a/template/sections/cta/banner/readme.MD
+++ b/template/sections/cta/banner/readme.MD
@@ -1,0 +1,70 @@
+# \ud83d\udcc2 Banner `/sections/cta/banner`
+
+Prominent call-to-action banner for highlighting promotions or important actions. Displays a title, optional description, and button.
+
+## \u2705 Features
+
+-   Optional title, description, and button (conditionally rendered)
+-   Responsive typography and spacing
+-   Centralized theming support via global design tokens
+
+---
+
+## \ud83d\uddcf\ufe0f Section Data Schema
+
+```json
+{
+        "src": "/sections/cta/banner/banner.html",
+        "title": "Ready to get started?",
+        "description": "Sign up today and enjoy all the benefits.",
+        "button": { "url": "/signup", "label": "Get Started" }
+}
+```
+
+## \ud83e\uddf1 HTML Structure
+
+```html
+<div class="banner">
+        {% if section.title %}
+        <div class="banner__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="banner__description">{{{section.description}}}</div>
+        {% endif %}
+        {% if section.button %}
+        <div class="banner__action">
+                <a href="{{{section.button.url}}}" class="banner__button">{{{section.button.label}}}</a>
+        </div>
+        {% endif %}
+</div>
+```
+
+---
+
+## \ud83c\udfa8 Styling Notes
+
+-   Uses `--c-primary` for the banner background and `--c-text-primary` for text
+-   Button background uses `--c-secondary` and transitions to `--c-primary-hover` on hover
+-   Spacing scales with `--padding-scale` and `--margin-scale`
+-   Responsive font sizes adjust at `--bp-md` and `--bp-sm`
+
+---
+
+## \ud83e\udde9 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| ------------------------------- | -------------------------------------------------- |
+| `--padding-scale` | Scales padding values in the banner |
+| `--margin-scale` | Controls margin spacing |
+| `--font-size` | Base font size for description and button |
+| `--line-height` | Line height for text |
+| `--letter-spacing` | Letter spacing for title and description |
+| `--b-radius` | Rounds banner and button corners |
+| `--transition` | Transition speed for button hover |
+| `--ff-base` | Font for description and button |
+| `--ff-title` | Font for title text |
+| `--c-primary` | Banner background color |
+| `--c-secondary` | Button background color |
+| `--c-primary-hover` | Button hover background |
+| `--c-text-primary` | Text color |
+| `--bp-md`, `--bp-sm` | Breakpoints for responsive adjustments |


### PR DESCRIPTION
## Summary
- add CTA banner section with optional title, description and button
- document and style CTA banner using theme variables
- import banner styles into global stylesheet

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6893c6b6d58c833386fe89a4ba3a1da7