### PR TITLE
feat: add api docs layout section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -34,3 +34,4 @@
 @use "../sections/cta/exit-modal/exit-modal";
 @use "../sections/cta/promo/promo";
 @use "../sections/cta/sticky-footer/sticky-footer";
+@use "../sections/docs/api-layout/api-layout";

--- a/template/sections/docs/api-layout/_api-layout.scss
+++ b/template/sections/docs/api-layout/_api-layout.scss
@@ -1,0 +1,64 @@
+// api-layout section
+
+.api-layout {
+  font-family: var(--ff-base);
+  color: var(--c-text-primary);
+
+  &__title {
+    font-family: var(--ff-title);
+    font-size: 32px;
+    font-weight: 600;
+    margin-bottom: calc(20px * var(--margin-scale));
+  }
+
+  &__description {
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+    color: var(--c-text-body-secondary);
+    margin-bottom: calc(24px * var(--margin-scale));
+    max-width: 70ch;
+  }
+
+  &__endpoints {
+    display: flex;
+    flex-direction: column;
+    gap: calc(16px * var(--margin-scale));
+  }
+
+  &__endpoint {
+    padding: calc(16px * var(--padding-scale));
+    border: 1px solid var(--c-border);
+    border-radius: var(--b-radius);
+    background: var(--c-bg-item);
+  }
+
+  &__method {
+    font-weight: 600;
+    color: var(--c-primary);
+    margin-right: calc(8px * var(--margin-scale));
+    text-transform: uppercase;
+  }
+
+  &__path {
+    font-family: var(--ff-second);
+    word-break: break-all;
+  }
+
+  &__endpoint-description {
+    margin-top: calc(8px * var(--margin-scale));
+    font-size: calc(var(--font-size) * 0.9);
+    color: var(--c-text-body-secondary);
+  }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+  .api-layout__title {
+    font-size: 24px;
+  }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+  .api-layout__title {
+    font-size: 20px;
+  }
+}

--- a/template/sections/docs/api-layout/api-layout.html
+++ b/template/sections/docs/api-layout/api-layout.html
@@ -1,0 +1,21 @@
+<div class="api-layout">
+  {% if section.title %}
+  <div class="api-layout__title">{{{section.title}}}</div>
+  {% endif %}
+  {% if section.description %}
+  <div class="api-layout__description">{{{section.description}}}</div>
+  {% endif %}
+  {% if section.endpoints %}
+  <div class="api-layout__endpoints">
+    {% for endpoint in section.endpoints %}
+    <div class="api-layout__endpoint">
+      <span class="api-layout__method">{{{endpoint.method}}}</span>
+      <span class="api-layout__path">{{{endpoint.path}}}</span>
+      {% if endpoint.description %}
+      <div class="api-layout__endpoint-description">{{{endpoint.description}}}</div>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>

--- a/template/sections/docs/api-layout/readme.MD
+++ b/template/sections/docs/api-layout/readme.MD
@@ -1,0 +1,3 @@
+# API Layout
+
+Section component for displaying API endpoints.


### PR DESCRIPTION
## Summary
- add API documentation layout section with responsive styles
- register section styles in main stylesheet

## Testing
- `npm test` (fails: could not find package.json)

------
https://chatgpt.com/codex/tasks/task_e_689436298c508333aa1bfc997288c037