### PR TITLE
feat: add docs glossary section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -34,3 +34,4 @@
 @use "../sections/cta/exit-modal/exit-modal";
 @use "../sections/cta/promo/promo";
 @use "../sections/cta/sticky-footer/sticky-footer";
+@use "../sections/docs/glossary/glossary";

--- a/template/sections/docs/glossary/_glossary.scss
+++ b/template/sections/docs/glossary/_glossary.scss
@@ -1,0 +1,77 @@
+// glossary section
+
+.glossary {
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 36px;
+                font-weight: 600;
+                text-align: center;
+                text-transform: uppercase;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+                margin-bottom: calc(20px * var(--margin-scale));
+        }
+
+        &__letter {
+                font-family: var(--ff-title);
+                font-size: 24px;
+                font-weight: 600;
+                margin-top: calc(32px * var(--margin-scale));
+                color: var(--c-text-primary);
+        }
+
+        &__entry {
+                margin-top: calc(12px * var(--margin-scale));
+        }
+
+        &__term {
+                font-weight: 600;
+                color: var(--c-text-primary);
+        }
+
+        &__definition {
+                margin-top: calc(4px * var(--margin-scale));
+                color: var(--c-text-body-secondary);
+                line-height: var(--line-height);
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .glossary__title {
+                font-size: 28px;
+        }
+        .glossary__letter {
+                font-size: 20px;
+        }
+        .glossary__definition {
+                font-size: calc(var(--font-size) * 0.95);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .glossary__title {
+                font-size: 24px;
+        }
+        .glossary__letter {
+                font-size: 18px;
+        }
+        .glossary__definition {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .glossary__title {
+                font-size: 20px;
+        }
+        .glossary__letter {
+                font-size: 16px;
+        }
+        .glossary__definition {
+                font-size: calc(var(--font-size) * 0.875);
+        }
+}

--- a/template/sections/docs/glossary/glossary.html
+++ b/template/sections/docs/glossary/glossary.html
@@ -1,0 +1,24 @@
+<div class="glossary">
+        {% if section.title %}
+        <div class="glossary__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.items %}
+        {% set currentLetter = '' %}
+        <div class="glossary__groups">
+                {% for item in section.items %}
+                {% set letter = item.term[0] | upper %}
+                {% if letter != currentLetter %}
+                {% if not loop.first %}</div>{% endif %}
+                <div class="glossary__group">
+                        <div class="glossary__letter">{{ letter }}</div>
+                {% set currentLetter = letter %}
+                {% endif %}
+                <div class="glossary__entry">
+                        <div class="glossary__term">{{{item.term}}}</div>
+                        <div class="glossary__definition">{{{item.definition}}}</div>
+                </div>
+                {% if loop.last %}</div>{% endif %}
+                {% endfor %}
+        </div>
+        {% endif %}
+</div>

--- a/template/sections/docs/glossary/readme.MD
+++ b/template/sections/docs/glossary/readme.MD
@@ -1,0 +1,55 @@
+# 📒 Glossary `/sections/docs/glossary`
+
+Glossary section for documentation pages. Renders a list of terms with definitions grouped alphabetically.
+
+## ✅ Features
+
+- Optional section title
+- Automatic grouping by first letter
+- Responsive typography and spacing
+- Uses global CSS variables for colors, fonts, and breakpoints
+
+## 🗰 Section Data Schema
+
+```json
+{
+        "src": "/sections/docs/glossary/glossary.html",
+        "title": "Glossary",
+        "items": [
+                { "term": "API", "definition": "Application Programming Interface" },
+                { "term": "CLI", "definition": "Command Line Interface" }
+        ]
+}
+```
+
+## 📦 HTML Structure
+
+```html
+<div class="glossary">
+        <div class="glossary__title">Glossary</div>
+        <div class="glossary__groups">
+                <div class="glossary__group">
+                        <div class="glossary__letter">A</div>
+                        <div class="glossary__entry">
+                                <div class="glossary__term">API</div>
+                                <div class="glossary__definition">Application Programming Interface</div>
+                        </div>
+                </div>
+        </div>
+</div>
+```
+
+## 🧩 Theme Variables Used
+
+| Variable | Description |
+| --- | --- |
+| `--padding-scale` | Scales padding |
+| `--margin-scale` | Controls margin |
+| `--ff-base` | Base font family |
+| `--ff-title` | Font for titles and letters |
+| `--font-size` | Base font size |
+| `--line-height` | Line height |
+| `--letter-spacing` | Letter spacing |
+| `--c-text-primary` | Primary text color |
+| `--c-text-body-secondary` | Definition text color |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Responsive breakpoints |


### PR DESCRIPTION
## Summary
- add docs glossary section with alphabetized term grouping
- document glossary section usage and styling

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894364ab4308333805fc71aa4c9f2a4