### PR TITLE
feat: add ecommerce variant selector section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -42,3 +42,4 @@
 @use "../sections/docs/glossary/glossary";
 @use "../sections/docs/api-layout/api-layout";
 @use "../sections/docs/page-layout/page-layout";
+@use "../sections/ecommerce/variant-selector/variant-selector";

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -150,3 +150,41 @@ document.addEventListener("DOMContentLoaded", () => {
                 const interval = setInterval(update, 1000);
         });
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll(".variant-selector").forEach((selector) => {
+                const options = selector.querySelectorAll(
+                        ".variant-selector__option"
+                );
+                const img = selector.querySelector(
+                        ".variant-selector__image"
+                );
+                const price = selector.querySelector(
+                        ".variant-selector__price"
+                );
+
+                const setActive = (option) => {
+                        options.forEach((o) =>
+                                o.classList.remove(
+                                        "variant-selector__option--active"
+                                )
+                        );
+                        option.classList.add(
+                                "variant-selector__option--active"
+                        );
+                        if (img && option.dataset.img) {
+                                img.src = option.dataset.img;
+                        }
+                        if (price && option.dataset.price) {
+                                price.textContent = option.dataset.price;
+                        }
+                };
+
+                options.forEach((option, index) => {
+                        option.addEventListener("click", () => setActive(option));
+                        if (index === 0) {
+                                setActive(option);
+                        }
+                });
+        });
+});

--- a/template/sections/ecommerce/variant-selector/_variant-selector.scss
+++ b/template/sections/ecommerce/variant-selector/_variant-selector.scss
@@ -1,0 +1,86 @@
+// variant-selector section
+
+.variant-selector {
+        font-family: var(--ff-base);
+        display: flex;
+        flex-direction: column;
+        gap: calc(16px * var(--margin-scale));
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: calc(var(--font-size) * 1.25);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-primary);
+        }
+
+        &__options {
+                display: flex;
+                flex-wrap: wrap;
+                gap: calc(8px * var(--margin-scale));
+        }
+
+        &__option {
+                display: flex;
+                align-items: center;
+                gap: calc(8px * var(--margin-scale));
+                padding: calc(8px * var(--padding-scale))
+                        calc(12px * var(--padding-scale));
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-secondary);
+                background: var(--c-white);
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                cursor: pointer;
+                transition: background var(--transition),
+                        color var(--transition),
+                        border-color var(--transition);
+        }
+
+        &__option--active {
+                background: var(--c-primary);
+                border-color: var(--c-primary);
+                color: var(--c-text-primary);
+        }
+
+        &__swatch {
+                width: 16px;
+                height: 16px;
+                border-radius: 50%;
+                flex-shrink: 0;
+                border: 1px solid var(--c-border);
+        }
+
+        &__display {
+                display: flex;
+                align-items: center;
+                gap: calc(16px * var(--margin-scale));
+        }
+
+        &__image {
+                width: 80px;
+                height: 80px;
+                object-fit: cover;
+                border-radius: var(--b-radius);
+                border: 1px solid var(--c-border);
+        }
+
+        &__price {
+                font-size: calc(var(--font-size) * 1.1);
+                font-weight: 600;
+                color: var(--c-text-primary);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .variant-selector__image {
+                width: 60px;
+                height: 60px;
+        }
+        .variant-selector__option {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+

--- a/template/sections/ecommerce/variant-selector/readme.MD
+++ b/template/sections/ecommerce/variant-selector/readme.MD
@@ -1,0 +1,89 @@
+# 📂 Variant Selector `/sections/ecommerce/variant-selector`
+
+Interactive selector for choosing between product variants such as color or size.
+Displays image and price of the active variant and updates instantly when a new
+option is selected.
+
+## ✅ Features
+
+-   Optional title
+-   Renders buttons for variant options
+-   Supports color swatches and labels
+-   Displays image and price for the selected variant
+-   No page reloads — selection handled in JavaScript
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/ecommerce/variant-selector/variant-selector.html",
+        "title": "Choose a variant",
+        "options": [
+                {
+                        "label": "Red",
+                        "color": "#ff0000",
+                        "img": "/img/red.jpg",
+                        "price": "$19.99"
+                },
+                {
+                        "label": "Blue",
+                        "color": "#0000ff",
+                        "img": "/img/blue.jpg",
+                        "price": "$21.99"
+                }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="variant-selector">
+        <div class="variant-selector__title">...</div>
+        <div class="variant-selector__options">
+                <button class="variant-selector__option" data-img="" data-price="">
+                        <span class="variant-selector__swatch"></span>
+                        <span class="variant-selector__label"></span>
+                </button>
+        </div>
+        <div class="variant-selector__display">
+                <img class="variant-selector__image" src="" alt="" />
+                <div class="variant-selector__price"></div>
+        </div>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses global CSS variables for colors, typography, spacing and responsiveness
+-   Active option styled using `--c-primary` and `--c-text-primary`
+-   Responsive adjustments at the `--bp-md` breakpoint
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                  | Description                         |
+| ------------------------- | ----------------------------------- |
+| `--ff-base`               | Base font family                    |
+| `--ff-title`              | Title font family                   |
+| `--font-size`             | Base font size                      |
+| `--line-height`           | Base line height                    |
+| `--letter-spacing`        | Letter spacing                      |
+| `--padding-scale`         | Scales padding                      |
+| `--margin-scale`          | Scales margin                       |
+| `--c-text-primary`        | Primary text color                  |
+| `--c-text-secondary`      | Secondary text color                |
+| `--c-primary`             | Primary brand color                 |
+| `--c-white`               | White background for options        |
+| `--c-border`              | Border color                        |
+| `--b-radius`              | Border radius for elements          |
+| `--transition`            | Transition timing                   |
+| `--bp-md`                 | Medium breakpoint for responsiveness |
+
+---
+

--- a/template/sections/ecommerce/variant-selector/variant-selector.html
+++ b/template/sections/ecommerce/variant-selector/variant-selector.html
@@ -1,0 +1,33 @@
+<div class="variant-selector">
+        {% if section.title %}
+        <div class="variant-selector__title">{{{section.title}}}</div>
+        {% endif %}
+
+        {% if section.options %}
+        <div class="variant-selector__options">
+                {% for option in section.options %}
+                <button
+                        class="variant-selector__option"
+                        data-img="{{{option.img}}}"
+                        data-price="{{{option.price}}}"
+                >
+                        {% if option.color %}
+                        <span
+                                class="variant-selector__swatch"
+                                style="background-color: {{{option.color}}}"
+                        ></span>
+                        {% endif %}
+                        {% if option.label %}
+                        <span class="variant-selector__label">{{{option.label}}}</span>
+                        {% endif %}
+                </button>
+                {% endfor %}
+        </div>
+
+        <div class="variant-selector__display">
+                <img class="variant-selector__image" src="" alt="" />
+                <div class="variant-selector__price"></div>
+        </div>
+        {% endif %}
+</div>
+


### PR DESCRIPTION
## Summary
- add ecommerce variant selector section with HTML, SCSS and docs
- hook variant selector styles into global index.scss and add JS logic

## Testing
- `node --check template/js/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68943eee5c9c8333bff7b9e4ada87b1b