### PR TITLE
feat: add ecommerce price section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -42,3 +42,4 @@
 @use "../sections/docs/glossary/glossary";
 @use "../sections/docs/api-layout/api-layout";
 @use "../sections/docs/page-layout/page-layout";
+@use "../sections/ecommerce/price/price";

--- a/template/sections/ecommerce/price/_price.scss
+++ b/template/sections/ecommerce/price/_price.scss
@@ -1,0 +1,49 @@
+// price section
+
+.price {
+        display: flex;
+        align-items: baseline;
+        font-family: var(--ff-base);
+
+        &__current {
+                font-size: calc(var(--font-size) * 1.5);
+                font-weight: 700;
+                color: var(--c-primary);
+        }
+
+        &__original {
+                font-size: calc(var(--font-size) * 1.1);
+                color: var(--c-text-body-secondary);
+                text-decoration: line-through;
+                margin-right: calc(12px * var(--margin-scale));
+        }
+
+        &__currency {
+                font-size: calc(var(--font-size) * 0.75);
+                margin-right: calc(2px * var(--margin-scale));
+        }
+
+        &__note {
+                font-size: calc(var(--font-size) * 0.875);
+                color: var(--c-text-secondary);
+                margin-left: calc(12px * var(--margin-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .price__current {
+                font-size: calc(var(--font-size) * 1.25);
+        }
+        .price__original {
+                font-size: var(--font-size);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .price__current {
+                font-size: calc(var(--font-size) * 1.1);
+        }
+        .price__note {
+                font-size: calc(var(--font-size) * 0.75);
+        }
+}

--- a/template/sections/ecommerce/price/price.html
+++ b/template/sections/ecommerce/price/price.html
@@ -1,0 +1,13 @@
+<div class="price">
+        {% if section.original %}
+        <div class="price__original">
+                {% if section.currency %}<span class="price__currency">{{{section.currency}}}</span>{% endif %}{{{section.original}}}
+        </div>
+        {% endif %}
+        <div class="price__current">
+                {% if section.currency %}<span class="price__currency">{{{section.currency}}}</span>{% endif %}{{{section.current}}}
+        </div>
+        {% if section.note %}
+        <div class="price__note">{{{section.note}}}</div>
+        {% endif %}
+</div>

--- a/template/sections/ecommerce/price/readme.MD
+++ b/template/sections/ecommerce/price/readme.MD
@@ -1,0 +1,70 @@
+# 📂 Price `/sections/ecommerce/price`
+
+Reusable pricing block for e‑commerce interfaces. Displays the current price with optional original price and note, while supporting custom currency symbols and responsive typography.
+
+## ✅ Features
+
+-   Highlights current price with optional strikethrough original price
+-   Supports optional currency symbol and auxiliary note
+-   Responsive font sizing across breakpoints
+-   Uses CSS variables for colors, fonts and spacing
+-   Flex layout aligns price elements on a single line
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/ecommerce/price/price.html",
+        "currency": "$",
+        "current": "19.99",
+        "original": "24.99",
+        "note": "per item"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="price">
+        {% if section.original %}
+        <div class="price__original">
+                {% if section.currency %}<span class="price__currency">{{{section.currency}}}</span>{% endif %}{{{section.original}}}
+        </div>
+        {% endif %}
+        <div class="price__current">
+                {% if section.currency %}<span class="price__currency">{{{section.currency}}}</span>{% endif %}{{{section.current}}}
+        </div>
+        {% if section.note %}
+        <div class="price__note">{{{section.note}}}</div>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Currency symbol rendered smaller via `.price__currency`
+-   Original price is muted and struck through when provided
+-   Uses `calc(... * var(--margin-scale))` and `--font-size` for scalable sizing
+-   Breakpoints adjust typography for smaller screens
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                  | Description                               |
+| ------------------------- | ----------------------------------------- |
+| `--font-size`             | Base font size for price values           |
+| `--ff-base`               | Base font family                          |
+| `--margin-scale`          | Spacing scale for margins                 |
+| `--c-primary`             | Color for current price                   |
+| `--c-text-body-secondary` | Color for original price                  |
+| `--c-text-secondary`      | Color for note                            |
+| `--bp-md`, `--bp-sm`      | Breakpoints for responsive font sizing    |
+
+---


### PR DESCRIPTION
## Summary
- create ecommerce price section with current and original price logic
- style price block with theme variables and responsive adjustments
- document price section usage and schema

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_68943e9ffa4c8333a5929f28552d0422