### PR TITLE
Add ecommerce discount badge section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -42,3 +42,4 @@
 @use "../sections/docs/glossary/glossary";
 @use "../sections/docs/api-layout/api-layout";
 @use "../sections/docs/page-layout/page-layout";
+@use "../sections/ecommerce/discount-badge/discount-badge";

--- a/template/sections/ecommerce/discount-badge/_discount-badge.scss
+++ b/template/sections/ecommerce/discount-badge/_discount-badge.scss
@@ -1,0 +1,35 @@
+// discount badge section
+
+.discount-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--ff-base);
+        font-size: calc(var(--font-size) * 0.875);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        background-color: var(--c-error);
+        color: var(--c-text-primary);
+        padding: calc(4px * var(--padding-scale)) calc(8px * var(--padding-scale));
+        border-radius: var(--b-radius);
+        font-weight: 600;
+        transition: background-color var(--transition);
+
+        &:hover {
+                background-color: var(--c-error-hover);
+        }
+
+        &__value {
+                margin-right: calc(4px * var(--margin-scale));
+        }
+
+        &__label {
+                font-weight: 400;
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .discount-badge {
+                font-size: calc(var(--font-size) * 0.75);
+        }
+}

--- a/template/sections/ecommerce/discount-badge/discount-badge.html
+++ b/template/sections/ecommerce/discount-badge/discount-badge.html
@@ -1,0 +1,7 @@
+<div class="discount-badge">
+        {% if section.discount %}
+        <span class="discount-badge__value">-{{{section.discount}}}%</span>
+        {% endif %} {% if section.label %}
+        <span class="discount-badge__label">{{{section.label}}}</span>
+        {% endif %}
+</div>

--- a/template/sections/ecommerce/discount-badge/readme.MD
+++ b/template/sections/ecommerce/discount-badge/readme.MD
@@ -1,0 +1,61 @@
+# 📂 Discount Badge `/sections/ecommerce/discount-badge`
+
+A badge to highlight a percentage discount with optional label text.
+
+## ✅ Features
+
+-   Displays discount value with optional label
+-   Responsive typography and spacing
+-   Uses CSS variables for colors, fonts, and spacing
+-   Hover state driven by theme variables
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/ecommerce/discount-badge/discount-badge.html",
+        "discount": 20,
+        "label": "OFF"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="discount-badge">
+        {% if section.discount %}
+        <span class="discount-badge__value">-{{{section.discount}}}%</span>
+        {% endif %} {% if section.label %}
+        <span class="discount-badge__label">{{{section.label}}}</span>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Background and hover colors use `--c-error` and `--c-error-hover`
+-   Typography and spacing rely on global design tokens
+-   Responsive sizing at `--bp-md`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| --- | --- |
+| `--ff-base` | Font for badge text |
+| `--font-size` | Base font size |
+| `--line-height` | Line height |
+| `--letter-spacing` | Letter spacing |
+| `--padding-scale` | Controls padding |
+| `--margin-scale` | Space between value and label |
+| `--b-radius` | Border radius |
+| `--c-error` | Background color |
+| `--c-error-hover` | Hover background color |
+| `--c-text-primary` | Text color |
+| `--bp-md` | Responsive breakpoint |
+| `--transition` | Transition duration |


### PR DESCRIPTION
## Summary
- implement ecommerce discount badge section with responsive styling
- document usage and theme variables
- register discount badge styles in global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943e8515348333ae5762c3764f0a8f