### PR TITLE
fix: use triple curly braces in sections templates

### DIFF
--- a/template/sections/docs/glossary/glossary.html
+++ b/template/sections/docs/glossary/glossary.html
@@ -10,7 +10,7 @@
                 {% if letter != currentLetter %}
                 {% if not loop.first %}</div>{% endif %}
                 <div class="glossary__group">
-                        <div class="glossary__letter">{{ letter }}</div>
+                        <div class="glossary__letter">{{{letter}}}</div>
                 {% set currentLetter = letter %}
                 {% endif %}
                 <div class="glossary__entry">

--- a/template/sections/ecommerce/payment-logos/payment-logos.html
+++ b/template/sections/ecommerce/payment-logos/payment-logos.html
@@ -1,7 +1,7 @@
 <div class="payment-logos">
 	{% for logo in section.logos %}
 	<div class="payment-logos__item">
-		<img src="{{{logo.img}}}" alt="{{logo.alt}}" />
+                <img src="{{{logo.img}}}" alt="{{{logo.alt}}}" />
 	</div>
 	{% endfor %}
 </div>

--- a/template/sections/ecommerce/payment-logos/readme.MD
+++ b/template/sections/ecommerce/payment-logos/readme.MD
@@ -28,7 +28,7 @@ Displays a row of accepted payment method logos. Useful in checkout pages or foo
 <div class="payment-logos">
 	{% for logo in section.logos %}
 	<div class="payment-logos__item">
-		<img src="{{{logo.img}}}" alt="{{logo.alt}}" />
+                <img src="{{{logo.img}}}" alt="{{{logo.alt}}}" />
 	</div>
 	{% endfor %}
 </div>

--- a/template/sections/ecommerce/product-card/product-card.html
+++ b/template/sections/ecommerce/product-card/product-card.html
@@ -1,6 +1,6 @@
 <div class="product-card">
 	<div class="product-card__img">
-		<img src="{{{section.img}}}" alt="{{section.title}}" />
+                <img src="{{{section.img}}}" alt="{{{section.title}}}" />
 	</div>
 	{% if section.title %}
 	<div class="product-card__title">{{{section.title}}}</div>

--- a/template/sections/ecommerce/product-card/readme.MD
+++ b/template/sections/ecommerce/product-card/readme.MD
@@ -31,7 +31,7 @@ This section expects the following data structure passed via `section`:
 ```html
 <div class="product-card">
 	<div class="product-card__img">
-		<img src="{{{section.img}}}" alt="{{section.title}}" />
+                <img src="{{{section.img}}}" alt="{{{section.title}}}" />
 	</div>
 	{% if section.title %}
 	<div class="product-card__title">{{{section.title}}}</div>

--- a/template/sections/ecommerce/product-details/product-details.html
+++ b/template/sections/ecommerce/product-details/product-details.html
@@ -1,6 +1,6 @@
 <div class="product-details">
 	<div class="product-details__image">
-		<img src="{{{section.img}}}" alt="{{section.title}}" />
+                <img src="{{{section.img}}}" alt="{{{section.title}}}" />
 	</div>
 	<div class="product-details__info">
 		{% if section.title %}

--- a/template/sections/ecommerce/product-details/readme.MD
+++ b/template/sections/ecommerce/product-details/readme.MD
@@ -35,7 +35,7 @@ This section expects the following structure passed via `section`:
 ```html
 <div class="product-details">
 	<div class="product-details__image">
-		<img src="{{{section.img}}}" alt="{{section.title}}" />
+                <img src="{{{section.img}}}" alt="{{{section.title}}}" />
 	</div>
 	<div class="product-details__info">
 		{% if section.title %}

--- a/template/sections/ecommerce/stock-indicator/readme.MD
+++ b/template/sections/ecommerce/stock-indicator/readme.MD
@@ -36,7 +36,7 @@ low = section.low or 10 %} {% set percent = (qty / max) * 100 %}
 	<div class="stock-indicator__bar">
 		<div
 			class="stock-indicator__progress{% if qty <= 0 %} stock-indicator__progress--out{% elseif qty <= low %} stock-indicator__progress--low{% else %} stock-indicator__progress--in{% endif %}"
-			style="width: {{ percent }}%"
+                        style="width: {{{percent}}}%"
 		></div>
 	</div>
 	{% if qty <= 0 %}

--- a/template/sections/ecommerce/stock-indicator/stock-indicator.html
+++ b/template/sections/ecommerce/stock-indicator/stock-indicator.html
@@ -4,7 +4,7 @@ low = section.low or 10 %} {% set percent = (qty / max) * 100 %}
 	<div class="stock-indicator__bar">
 		<div
 			class="stock-indicator__progress{% if qty <= 0 %} stock-indicator__progress--out{% elseif qty <= low %} stock-indicator__progress--low{% else %} stock-indicator__progress--in{% endif %}"
-			style="width: {{ percent }}%"
+                        style="width: {{{percent}}}%"
 		></div>
 	</div>
 	{% if qty <= 0 %}


### PR DESCRIPTION
## Summary
- ensure product detail, product card, and payment logos templates use triple-curly interpolation for wjst variables
- update corresponding documentation to match triple-curly usage

## Testing
- `npm test` (fails: ENOENT could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6894fae1530c8333b70984b3e82304ba