### PR TITLE
feat: add education certificate section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/education/certificate/certificate";

--- a/template/sections/education/certificate/LICENSE
+++ b/template/sections/education/certificate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/education/certificate/_certificate.scss
+++ b/template/sections/education/certificate/_certificate.scss
@@ -1,0 +1,78 @@
+// certificate section
+
+.certificate {
+        max-width: 600px;
+        margin: 0 auto;
+        padding: calc(40px * var(--padding-scale));
+        border: 1px solid var(--c-border);
+        border-radius: var(--b-radius);
+        background-color: var(--c-bg-item);
+        text-align: center;
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__recipient {
+                margin-top: calc(20px * var(--margin-scale));
+                font-size: 24px;
+                font-weight: 500;
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__course {
+                margin-top: calc(12px * var(--margin-scale));
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+        }
+
+        &__meta {
+                margin-top: calc(20px * var(--margin-scale));
+                font-size: calc(var(--font-size) * 0.875);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                display: flex;
+                justify-content: center;
+                gap: calc(12px * var(--padding-scale));
+        }
+
+        &__id {
+                margin-top: calc(12px * var(--margin-scale));
+                font-size: calc(var(--font-size) * 0.75);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .certificate {
+                padding: calc(30px * var(--padding-scale));
+        }
+        .certificate__title {
+                font-size: 28px;
+        }
+        .certificate__recipient {
+                font-size: 20px;
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .certificate__title {
+                font-size: 24px;
+        }
+        .certificate__recipient {
+                font-size: 18px;
+        }
+}

--- a/template/sections/education/certificate/certificate.html
+++ b/template/sections/education/certificate/certificate.html
@@ -1,0 +1,24 @@
+<div class="certificate">
+        {% if section.title %}
+        <div class="certificate__title">{{{section.title}}}</div>
+        {% endif %}
+
+        {% if section.recipient %}
+        <div class="certificate__recipient">{{{section.recipient}}}</div>
+        {% endif %}
+
+        {% if section.course %}
+        <div class="certificate__course">{{{section.course}}}</div>
+        {% endif %}
+
+        {% if section.issuer or section.date %}
+        <div class="certificate__meta">
+                {% if section.issuer %}<span class="certificate__issuer">{{{section.issuer}}}</span>{% endif %}
+                {% if section.date %}<span class="certificate__date">{{{section.date}}}</span>{% endif %}
+        </div>
+        {% endif %}
+
+        {% if section.id %}
+        <div class="certificate__id">{{{section.id}}}</div>
+        {% endif %}
+</div>

--- a/template/sections/education/certificate/module.json
+++ b/template/sections/education/certificate/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-education-certificate.git" }

--- a/template/sections/education/certificate/readme.MD
+++ b/template/sections/education/certificate/readme.MD
@@ -1,0 +1,72 @@
+# 📂 Certificate `/sections/education/certificate`
+
+Certificate section for showcasing a course or program completion. Displays recipient, course title and issuing details inside a styled card.
+
+## ✅ Features
+
+-   Optional title, recipient, course name and meta info
+-   Responsive layout using CSS variables and breakpoints
+-   Centralized theming via global design tokens
+
+---
+
+## 📞 Section Data Schema
+
+```json
+{
+        "src": "/sections/education/certificate/certificate.html",
+        "title": "Certificate of Completion",
+        "recipient": "John Doe",
+        "course": "Intro to Web Development",
+        "issuer": "Web Art Work Academy",
+        "date": "2024-01-01",
+        "id": "ABC123"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="certificate">
+        {% if section.title %}
+        <div class="certificate__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.recipient %}
+        <div class="certificate__recipient">{{{section.recipient}}}</div>
+        {% endif %}
+        {% if section.course %}
+        <div class="certificate__course">{{{section.course}}}</div>
+        {% endif %}
+        {% if section.issuer or section.date %}
+        <div class="certificate__meta">
+                {% if section.issuer %}<span class="certificate__issuer">{{{section.issuer}}}</span>{% endif %}
+                {% if section.date %}<span class="certificate__date">{{{section.date}}}</span>{% endif %}
+        </div>
+        {% endif %}
+        {% if section.id %}
+        <div class="certificate__id">{{{section.id}}}</div>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Theme Variables Used (from `template.json`)
+
+| Variable                  | Description                               |
+| ------------------------- | ----------------------------------------- |
+| `--padding-scale`         | Scales padding values in card             |
+| `--margin-scale`          | Controls spacing between elements         |
+| `--font-size`             | Base font size for course text            |
+| `--line-height`           | Line height for all text                  |
+| `--letter-spacing`        | Letter spacing for title and text         |
+| `--b-radius`              | Rounds the card corners                   |
+| `--c-border`              | Border color of certificate card          |
+| `--c-bg-item`             | Background color of certificate card      |
+| `--c-text-primary`        | Main title and recipient text color       |
+| `--c-text-body-secondary` | Color for course, meta and id text        |
+| `--ff-base`               | Font for body text                        |
+| `--ff-title`              | Font for title text                       |
+| `--bp-md`, `--bp-sm`      | Breakpoints for responsive adjustments    |
+
+---


### PR DESCRIPTION
## Summary
- add education certificate section with documentation
- style certificate card using theme variables
- include certificate styles in global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef06fa748333a7125c00d33905ae