### PR TITLE
feat: add education comparison table section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,37 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.comparison-table {
+        overflow-x: auto;
+        padding: calc(40px * var(--padding-scale)) 0;
+        font-family: var(--ff-base);
+}
+.comparison-table__table {
+        width: 100%;
+        border-collapse: collapse;
+        box-shadow: 0 0 10px var(--c-table-shadow);
+}
+.comparison-table__table th,
+.comparison-table__table td {
+        padding: calc(12px * var(--padding-scale)) calc(16px * var(--padding-scale));
+        border: 1px solid var(--c-border);
+        text-align: center;
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-primary);
+}
+.comparison-table__table th {
+        font-family: var(--ff-title);
+        background-color: var(--c-secondary);
+        color: var(--c-text-primary);
+}
+.comparison-table__table tbody tr:nth-child(odd) {
+        background-color: var(--c-table-striped);
+}
+@media screen and (max-width: var(--bp-md)) {
+        .comparison-table__table th,
+        .comparison-table__table td {
+                font-size: calc(var(--font-size) * 0.95);
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/education/comparison-table/comparison-table";

--- a/template/sections/education/comparison-table/LICENSE
+++ b/template/sections/education/comparison-table/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/education/comparison-table/_comparison-table.scss
+++ b/template/sections/education/comparison-table/_comparison-table.scss
@@ -1,0 +1,41 @@
+// comparison table section
+
+.comparison-table {
+        overflow-x: auto;
+        padding: calc(40px * var(--padding-scale)) 0;
+        font-family: var(--ff-base);
+
+        &__table {
+                width: 100%;
+                border-collapse: collapse;
+                box-shadow: 0 0 10px var(--c-table-shadow);
+
+                th,
+                td {
+                        padding: calc(12px * var(--padding-scale)) calc(16px * var(--padding-scale));
+                        border: 1px solid var(--c-border);
+                        text-align: center;
+                        font-size: var(--font-size);
+                        line-height: var(--line-height);
+                        letter-spacing: var(--letter-spacing);
+                        color: var(--c-text-primary);
+                }
+
+                th {
+                        font-family: var(--ff-title);
+                        background-color: var(--c-secondary);
+                        color: var(--c-text-primary);
+                }
+
+                tbody tr:nth-child(odd) {
+                        background-color: var(--c-table-striped);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .comparison-table__table th,
+        .comparison-table__table td {
+                font-size: calc(var(--font-size) * 0.95);
+        }
+}

--- a/template/sections/education/comparison-table/comparison-table.html
+++ b/template/sections/education/comparison-table/comparison-table.html
@@ -1,0 +1,25 @@
+<div class="comparison-table">
+        <table class="comparison-table__table">
+                {% if section.headers %}
+                <thead>
+                        <tr>
+                                <th></th>
+                                {% for head in section.headers %}
+                                <th>{{{head}}}</th>
+                                {% endfor %}
+                        </tr>
+                </thead>
+                {% endif %} {% if section.rows %}
+                <tbody>
+                        {% for row in section.rows %}
+                        <tr>
+                                <th>{{{row.feature}}}</th>
+                                {% for value in row.values %}
+                                <td>{{{value}}}</td>
+                                {% endfor %}
+                        </tr>
+                        {% endfor %}
+                </tbody>
+                {% endif %}
+        </table>
+</div>

--- a/template/sections/education/comparison-table/module.json
+++ b/template/sections/education/comparison-table/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-education-comparison-table.git" }

--- a/template/sections/education/comparison-table/readme.MD
+++ b/template/sections/education/comparison-table/readme.MD
@@ -1,0 +1,93 @@
+# 📂 Comparison Table `/sections/education/comparison-table`
+
+Display a feature comparison of courses or study options using a responsive table. Columns and rows are fully data-driven.
+
+## ✅ Features
+
+-   Dynamic headers and rows rendered conditionally
+-   Responsive layout with horizontal scroll on small screens
+-   Zebra striping for better readability
+-   Theming via CSS variables for colors, fonts and spacing
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/education/comparison-table/comparison-table.html",
+        "headers": ["Basic", "Pro", "Enterprise"],
+        "rows": [
+                {
+                        "feature": "Lessons",
+                        "values": ["10", "20", "30"]
+                },
+                {
+                        "feature": "Certificates",
+                        "values": ["No", "Yes", "Yes"]
+                }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="comparison-table">
+        <table class="comparison-table__table">
+                {% if section.headers %}
+                <thead>
+                        <tr>
+                                <th></th>
+                                {% for head in section.headers %}
+                                <th>{{{head}}}</th>
+                                {% endfor %}
+                        </tr>
+                </thead>
+                {% endif %} {% if section.rows %}
+                <tbody>
+                        {% for row in section.rows %}
+                        <tr>
+                                <th>{{{row.feature}}}</th>
+                                {% for value in row.values %}
+                                <td>{{{value}}}</td>
+                                {% endfor %}
+                        </tr>
+                        {% endfor %}
+                </tbody>
+                {% endif %}
+        </table>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Padding and font sizing scale with `--padding-scale` and `--font-size`
+-   Uses `--c-table-shadow` and `--c-table-striped` for visual hierarchy
+-   Row headers use `--ff-title` for emphasis
+-   Responsive font adjustment at `--bp-md`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable              | Description                                    |
+| --------------------- | ---------------------------------------------- |
+| `--padding-scale`     | Controls section padding                       |
+| `--font-size`         | Base font size for table text                  |
+| `--line-height`       | Line height for cells                          |
+| `--letter-spacing`    | Letter spacing for text                        |
+| `--ff-base`           | Font for table body text                       |
+| `--ff-title`          | Font for header cells                          |
+| `--c-secondary`       | Header background color                        |
+| `--c-text-primary`    | Text color for cells and headers               |
+| `--c-border`          | Border color for table cells                   |
+| `--c-table-shadow`    | Shadow applied to the table wrapper            |
+| `--c-table-striped`   | Background color for odd table rows            |
+| `--bp-md`             | Breakpoint for responsive font adjustments     |
+
+---


### PR DESCRIPTION
## Summary
- add comparison table section for educational pages
- document expected data structure and theme variables
- include styles in global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef11b1e08333abd043b379d6642f