### PR TITLE
feat: add lesson list education section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,72 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.lesson-list {
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+}
+.lesson-list__title {
+        text-align: center;
+        font-family: var(--ff-title);
+        font-size: 36px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: var(--letter-spacing);
+        line-height: var(--line-height);
+        color: var(--c-text-primary);
+}
+.lesson-list__items {
+        margin-top: calc(30px * var(--margin-scale));
+        list-style: none;
+        padding: 0;
+        max-width: 70ch;
+        margin-left: auto;
+        margin-right: auto;
+        display: flex;
+        flex-direction: column;
+        gap: calc(12px * var(--margin-scale));
+}
+.lesson-list__item {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--c-bg-item);
+        padding: calc(16px * var(--padding-scale));
+        border-radius: var(--b-radius);
+        box-shadow: 0 2px 4px var(--c-shadow);
+}
+.lesson-list__info {
+        display: flex;
+        align-items: center;
+        gap: calc(12px * var(--margin-scale));
+}
+.lesson-list__index {
+        font-family: var(--ff-title);
+        font-weight: 600;
+        color: var(--c-text-secondary);
+}
+.lesson-list__name {
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-primary);
+}
+.lesson-list__duration {
+        font-size: calc(var(--font-size) * 0.9);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-body-secondary);
+}
+.lesson-list__item--completed {
+        opacity: 0.6;
+}
+@media screen and (max-width: var(--bp-md)) {
+        .lesson-list__item {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: calc(8px * var(--margin-scale));
+        }
+        .lesson-list__duration {
+                margin-left: calc(24px * var(--margin-scale));
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/education/lesson-list/lesson-list";

--- a/template/sections/education/lesson-list/LICENSE
+++ b/template/sections/education/lesson-list/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/education/lesson-list/_lesson-list.scss
+++ b/template/sections/education/lesson-list/_lesson-list.scss
@@ -1,0 +1,82 @@
+// lesson-list section
+
+.lesson-list {
+    padding-bottom: calc(50px * var(--padding-scale));
+    font-family: var(--ff-base);
+
+    &__title {
+        text-align: center;
+        font-family: var(--ff-title);
+        font-size: 36px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: var(--letter-spacing);
+        line-height: var(--line-height);
+        color: var(--c-text-primary);
+    }
+
+    &__items {
+        margin-top: calc(30px * var(--margin-scale));
+        list-style: none;
+        padding: 0;
+        max-width: 70ch;
+        margin-left: auto;
+        margin-right: auto;
+        display: flex;
+        flex-direction: column;
+        gap: calc(12px * var(--margin-scale));
+    }
+
+    &__item {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--c-bg-item);
+        padding: calc(16px * var(--padding-scale));
+        border-radius: var(--b-radius);
+        box-shadow: 0 2px 4px var(--c-shadow);
+    }
+
+    &__info {
+        display: flex;
+        align-items: center;
+        gap: calc(12px * var(--margin-scale));
+    }
+
+    &__index {
+        font-family: var(--ff-title);
+        font-weight: 600;
+        color: var(--c-text-secondary);
+    }
+
+    &__name {
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-primary);
+    }
+
+    &__duration {
+        font-size: calc(var(--font-size) * 0.9);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-body-secondary);
+    }
+
+    &__item--completed {
+        opacity: 0.6;
+    }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+    .lesson-list__item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: calc(8px * var(--margin-scale));
+    }
+
+    .lesson-list__duration {
+        margin-left: calc(24px * var(--margin-scale));
+    }
+}
+

--- a/template/sections/education/lesson-list/lesson-list.html
+++ b/template/sections/education/lesson-list/lesson-list.html
@@ -1,0 +1,21 @@
+<div class="lesson-list">
+    {% if section.title %}
+    <div class="lesson-list__title">{{{section.title}}}</div>
+    {% endif %} {% if section.lessons %}
+    <ul class="lesson-list__items">
+        {% for lesson in section.lessons %}
+        <li class="lesson-list__item{% if lesson.completed %} lesson-list__item--completed{% endif %}">
+            <div class="lesson-list__info">
+                <span class="lesson-list__index">{{ loop.index }}</span>
+                {% if lesson.name %}
+                <span class="lesson-list__name">{{{lesson.name}}}</span>
+                {% endif %}
+            </div>
+            {% if lesson.duration %}
+            <span class="lesson-list__duration">{{{lesson.duration}}}</span>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>

--- a/template/sections/education/lesson-list/module.json
+++ b/template/sections/education/lesson-list/module.json
@@ -1,0 +1,3 @@
+{
+    "repo": "https://github.com/WebArtWork/wjst-section-education-lesson-list.git"
+}

--- a/template/sections/education/lesson-list/readme.MD
+++ b/template/sections/education/lesson-list/readme.MD
@@ -1,0 +1,76 @@
+# 📂 Lesson List `/sections/education/lesson-list`
+
+Displays an ordered list of lessons with optional duration and completion state.
+
+## ✅ Features
+
+-   Optional section title
+-   Renders lessons with automatic numbering
+-   Supports optional duration per lesson
+-   Visual hint for completed lessons
+-   Uses CSS variables for fonts, spacing, colors, and responsiveness
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+    "src": "/sections/education/lesson-list/lesson-list.html",
+    "title": "Course Outline",
+    "lessons": [
+        { "name": "Introduction", "duration": "5 min" },
+        { "name": "Deep dive", "duration": "10 min", "completed": true }
+    ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="lesson-list">
+    {% if section.title %}
+    <div class="lesson-list__title">{{{section.title}}}</div>
+    {% endif %} {% if section.lessons %}
+    <ul class="lesson-list__items">
+        {% for lesson in section.lessons %}
+        <li class="lesson-list__item{% if lesson.completed %} lesson-list__item--completed{% endif %}">
+            <div class="lesson-list__info">
+                <span class="lesson-list__index">{{ loop.index }}</span>
+                {% if lesson.name %}
+                <span class="lesson-list__name">{{{lesson.name}}}</span>
+                {% endif %}
+            </div>
+            {% if lesson.duration %}
+            <span class="lesson-list__duration">{{{lesson.duration}}}</span>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+```
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| --- | --- |
+| `--padding-scale` | Scales section padding |
+| `--margin-scale` | Controls gaps between lessons |
+| `--font-size` | Base font size |
+| `--line-height` | Base line height |
+| `--letter-spacing` | Default letter spacing |
+| `--ff-base` | Font for lesson text |
+| `--ff-title` | Font for title and indices |
+| `--c-text-primary` | Title and lesson color |
+| `--c-text-secondary` | Lesson index color |
+| `--c-text-body-secondary` | Duration text color |
+| `--c-bg-item` | Background of lesson card |
+| `--c-shadow` | Box shadow |
+| `--b-radius` | Border radius for items |
+| `--bp-md` | Breakpoint for responsive layout |
+


### PR DESCRIPTION
## Summary
- add lesson list section with templating, readme, and default module metadata
- wire new section styles into global stylesheet

## Testing
- `npx sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef6604348333a814085eba7a15be