### PR TITLE
feat: add syllabus education section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,72 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.syllabus {
+        padding: calc(40px * var(--padding-scale)) 0;
+        font-family: var(--ff-base);
+}
+.syllabus__title {
+        font-family: var(--ff-title);
+        font-size: 32px;
+        font-weight: 600;
+        text-align: center;
+        color: var(--c-text-primary);
+        margin-bottom: calc(24px * var(--margin-scale));
+}
+.syllabus__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+}
+.syllabus__module {
+        border-bottom: 1px solid var(--c-border);
+        padding: calc(16px * var(--padding-scale)) 0;
+}
+.syllabus__module-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+}
+.syllabus__module-title {
+        font-size: 20px;
+        font-weight: 500;
+        color: var(--c-text-primary);
+}
+.syllabus__module-duration {
+        font-size: 14px;
+        color: var(--c-text-secondary);
+}
+.syllabus__module-description {
+        margin-top: calc(8px * var(--margin-scale));
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        color: var(--c-text-body-secondary);
+}
+.syllabus__lessons {
+        list-style: none;
+        margin: calc(12px * var(--margin-scale)) 0 0;
+        padding-left: 0;
+}
+.syllabus__lesson {
+        display: flex;
+        justify-content: space-between;
+        padding: calc(4px * var(--padding-scale)) 0;
+}
+.syllabus__lesson-title {
+        color: var(--c-text-primary);
+        font-size: var(--font-size);
+}
+.syllabus__lesson-duration {
+        color: var(--c-text-secondary);
+        font-size: calc(var(--font-size) * 0.9);
+}
+@media screen and (max-width: var(--bp-md)) {
+        .syllabus__title {
+                font-size: 28px;
+        }
+}
+@media screen and (max-width: var(--bp-sm)) {
+        .syllabus__title {
+                font-size: 24px;
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/education/syllabus/syllabus";

--- a/template/sections/education/syllabus/LICENSE
+++ b/template/sections/education/syllabus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/education/syllabus/_syllabus.scss
+++ b/template/sections/education/syllabus/_syllabus.scss
@@ -1,0 +1,84 @@
+// syllabus section
+
+.syllabus {
+        padding: calc(40px * var(--padding-scale)) 0;
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                text-align: center;
+                color: var(--c-text-primary);
+                margin-bottom: calc(24px * var(--margin-scale));
+        }
+
+        &__list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+        }
+
+        &__module {
+                border-bottom: 1px solid var(--c-border);
+                padding: calc(16px * var(--padding-scale)) 0;
+        }
+
+        &__module-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: baseline;
+        }
+
+        &__module-title {
+                font-size: 20px;
+                font-weight: 500;
+                color: var(--c-text-primary);
+        }
+
+        &__module-duration {
+                font-size: 14px;
+                color: var(--c-text-secondary);
+        }
+
+        &__module-description {
+                margin-top: calc(8px * var(--margin-scale));
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                color: var(--c-text-body-secondary);
+        }
+
+        &__lessons {
+                list-style: none;
+                margin: calc(12px * var(--margin-scale)) 0 0;
+                padding-left: 0;
+        }
+
+        &__lesson {
+                display: flex;
+                justify-content: space-between;
+                padding: calc(4px * var(--padding-scale)) 0;
+        }
+
+        &__lesson-title {
+                color: var(--c-text-primary);
+                font-size: var(--font-size);
+        }
+
+        &__lesson-duration {
+                color: var(--c-text-secondary);
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .syllabus__title {
+                font-size: 28px;
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .syllabus__title {
+                font-size: 24px;
+        }
+}

--- a/template/sections/education/syllabus/module.json
+++ b/template/sections/education/syllabus/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-education-syllabus.git" }

--- a/template/sections/education/syllabus/readme.MD
+++ b/template/sections/education/syllabus/readme.MD
@@ -1,0 +1,96 @@
+# 📂 Syllabus `/sections/education/syllabus`
+
+Section for displaying a course syllabus. Supports optional section title, modules with durations and descriptions, and nested lesson lists.
+
+## ✅ Features
+
+-   Optional section title
+-   Modules with optional duration and description
+-   Nested lesson lists with optional durations
+-   Responsive typography via CSS variables
+-   Uses global design tokens for spacing, colors, and fonts
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/education/syllabus/syllabus.html",
+        "title": "Course Syllabus",
+        "modules": [
+                {
+                        "title": "Module title",
+                        "duration": "1h 20m",
+                        "description": "Optional module description",
+                        "lessons": [
+                                { "title": "Lesson one", "duration": "10m" },
+                                { "title": "Lesson two" }
+                        ]
+                }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="syllabus">
+        {% if section.title %}
+        <div class="syllabus__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.modules %}
+        <ul class="syllabus__list">
+                {% for module in section.modules %}
+                <li class="syllabus__module">
+                        <div class="syllabus__module-header">
+                                {% if module.title %}
+                                <div class="syllabus__module-title">{{{module.title}}}</div>
+                                {% endif %}
+                                {% if module.duration %}
+                                <div class="syllabus__module-duration">{{{module.duration}}}</div>
+                                {% endif %}
+                        </div>
+                        {% if module.description %}
+                        <div class="syllabus__module-description">{{{module.description}}}</div>
+                        {% endif %}
+                        {% if module.lessons %}
+                        <ul class="syllabus__lessons">
+                                {% for lesson in module.lessons %}
+                                <li class="syllabus__lesson">
+                                        <span class="syllabus__lesson-title">{{{lesson.title}}}</span>
+                                        {% if lesson.duration %}
+                                        <span class="syllabus__lesson-duration">{{{lesson.duration}}}</span>
+                                        {% endif %}
+                                </li>
+                                {% endfor %}
+                        </ul>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                               |
+| ------------------------------- | ----------------------------------------- |
+| `--padding-scale`               | Scales vertical padding                   |
+| `--margin-scale`                | Controls spacing between blocks           |
+| `--ff-base`                     | Base font for text                        |
+| `--ff-title`                    | Font for the section title                |
+| `--font-size`                   | Base font size for lessons and text       |
+| `--line-height`                 | Line height for module descriptions       |
+| `--c-text-primary`              | Title and item text color                 |
+| `--c-text-secondary`            | Duration text color                       |
+| `--c-text-body-secondary`       | Module description color                  |
+| `--c-border`                    | Divider line color                        |
+| `--bp-md`, `--bp-sm`            | Breakpoints for responsive typography     |
+
+---

--- a/template/sections/education/syllabus/syllabus.html
+++ b/template/sections/education/syllabus/syllabus.html
@@ -1,0 +1,36 @@
+<div class="syllabus">
+        {% if section.title %}
+        <div class="syllabus__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.modules %}
+        <ul class="syllabus__list">
+                {% for module in section.modules %}
+                <li class="syllabus__module">
+                        <div class="syllabus__module-header">
+                                {% if module.title %}
+                                <div class="syllabus__module-title">{{{module.title}}}</div>
+                                {% endif %}
+                                {% if module.duration %}
+                                <div class="syllabus__module-duration">{{{module.duration}}}</div>
+                                {% endif %}
+                        </div>
+                        {% if module.description %}
+                        <div class="syllabus__module-description">{{{module.description}}}</div>
+                        {% endif %}
+                        {% if module.lessons %}
+                        <ul class="syllabus__lessons">
+                                {% for lesson in module.lessons %}
+                                <li class="syllabus__lesson">
+                                        <span class="syllabus__lesson-title">{{{lesson.title}}}</span>
+                                        {% if lesson.duration %}
+                                        <span class="syllabus__lesson-duration">{{{lesson.duration}}}</span>
+                                        {% endif %}
+                                </li>
+                                {% endfor %}
+                        </ul>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add new education syllabus section with modules and lessons
- document and bundle syllabus styles
- compile CSS and link section in global index

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef7e4ab88333832b79b0bbf7a2ef