### PR TITLE
feat: add education timeline section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/education/timeline/timeline";

--- a/template/sections/education/timeline/LICENSE
+++ b/template/sections/education/timeline/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/education/timeline/_timeline.scss
+++ b/template/sections/education/timeline/_timeline.scss
@@ -1,0 +1,99 @@
+// timeline section
+
+.timeline {
+	font-family: var(--ff-base);
+	padding-left: calc(20px * var(--padding-scale));
+
+	&__title {
+		font-family: var(--ff-title);
+		font-size: 36px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--letter-spacing);
+		line-height: var(--line-height);
+		color: var(--c-text-primary);
+		text-align: center;
+		margin-bottom: calc(20px * var(--margin-scale));
+	}
+
+	&__description {
+		font-size: var(--font-size);
+		line-height: var(--line-height);
+		letter-spacing: var(--letter-spacing);
+		color: var(--c-text-body-secondary);
+		text-align: center;
+		margin: 0 auto calc(40px * var(--margin-scale));
+		max-width: 70ch;
+		transition: color var(--transition);
+	}
+
+	&__items {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		position: relative;
+	}
+
+	&__item {
+		position: relative;
+		padding: 0 0 calc(30px * var(--padding-scale))
+			calc(30px * var(--padding-scale));
+		border-left: 2px solid var(--c-border);
+
+		&::before {
+			content: "";
+			position: absolute;
+			left: -6px;
+			top: 0;
+			width: 12px;
+			height: 12px;
+			background: var(--c-primary);
+			border-radius: 50%;
+		}
+
+		&:last-child {
+			border-left: none;
+			padding-bottom: 0;
+		}
+	}
+
+	&__time {
+		font-family: var(--ff-title);
+		font-weight: 600;
+		color: var(--c-text-primary);
+		margin-bottom: calc(4px * var(--margin-scale));
+	}
+
+	&__label {
+		font-size: var(--font-size);
+		line-height: var(--line-height);
+		color: var(--c-text-secondary);
+	}
+
+	&__text {
+		font-size: calc(var(--font-size) * 0.95);
+		line-height: var(--line-height);
+		letter-spacing: var(--letter-spacing);
+		color: var(--c-text-body-secondary);
+		margin-top: calc(4px * var(--margin-scale));
+		transition: color var(--transition);
+	}
+}
+
+@media screen and (max-width: var(--bp-md)) {
+	.timeline__title {
+		font-size: 28px;
+	}
+	.timeline__description {
+		font-size: calc(var(--font-size) * 0.95);
+	}
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+	.timeline__title {
+		font-size: 24px;
+	}
+	.timeline__description {
+		font-size: calc(var(--font-size) * 0.9);
+	}
+}

--- a/template/sections/education/timeline/module.json
+++ b/template/sections/education/timeline/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-education-timeline.git" }

--- a/template/sections/education/timeline/readme.MD
+++ b/template/sections/education/timeline/readme.MD
@@ -1,0 +1,84 @@
+# 📂 Timeline `/sections/education/timeline`
+
+Education-focused vertical timeline for displaying chronological milestones like courses, exams, or achievements. Supports optional title and description with a list of items each containing time, label, and text.
+
+## ✅ Features
+
+-   Optional title and description
+-   Items rendered as vertical timeline
+-   Responsive layout and typography
+-   Uses CSS variables for theming and spacing
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+	"src": "/sections/education/timeline/timeline.html",
+	"title": "Optional section title",
+	"description": "Optional description text",
+	"items": [
+		{ "time": "2023", "label": "Started", "text": "Project kick-off" },
+		{ "time": "2024", "label": "Launch", "text": "First release" }
+	]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="timeline">
+	{% if section.title %}
+	<div class="timeline__title">{{{section.title}}}</div>
+	{% endif %} {% if section.description %}
+	<div class="timeline__description">{{{section.description}}}</div>
+	{% endif %} {% if section.items %}
+	<ul class="timeline__items">
+		{% for item in section.items %}
+		<li class="timeline__item">
+			{% if item.time %}
+			<div class="timeline__time">{{{item.time}}}</div>
+			{% endif %} {% if item.label %}
+			<div class="timeline__label">{{{item.label}}}</div>
+			{% endif %} {% if item.text %}
+			<div class="timeline__text">{{{item.text}}}</div>
+			{% endif %}
+		</li>
+		{% endfor %}
+	</ul>
+	{% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Timeline line and bullets inherit colors from `--c-border` and `--c-primary`
+-   Spacing scaled using `--padding-scale` and `--margin-scale`
+-   Fonts and colors driven by global theme variables
+-   Media queries adapt title and description at breakpoints
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                  | Description                         |
+| ------------------------- | ----------------------------------- |
+| `--padding-scale`         | Scales padding within the timeline  |
+| `--margin-scale`          | Controls margin spacing             |
+| `--font-size`             | Base font size for text             |
+| `--line-height`           | Line height for text                |
+| `--letter-spacing`        | Letter spacing for text             |
+| `--ff-base`               | Font for body text                  |
+| `--ff-title`              | Font for section title and time     |
+| `--c-text-primary`        | Title and time text color           |
+| `--c-text-secondary`      | Label text color                    |
+| `--c-text-body-secondary` | Description and item text color     |
+| `--c-border`              | Border color for the timeline line  |
+| `--c-primary`             | Color for timeline bullet markers   |
+| `--transition`            | Transition used for text color fade |
+| `--bp-md`, `--bp-sm`      | Breakpoints for responsive sizing   |
+
+---

--- a/template/sections/education/timeline/timeline.html
+++ b/template/sections/education/timeline/timeline.html
@@ -1,0 +1,21 @@
+<div class="timeline">
+	{% if section.title %}
+	<div class="timeline__title">{{{section.title}}}</div>
+	{% endif %} {% if section.description %}
+	<div class="timeline__description">{{{section.description}}}</div>
+	{% endif %} {% if section.items %}
+	<ul class="timeline__items">
+		{% for item in section.items %}
+		<li class="timeline__item">
+			{% if item.time %}
+			<div class="timeline__time">{{{item.time}}}</div>
+			{% endif %} {% if item.label %}
+			<div class="timeline__label">{{{item.label}}}</div>
+			{% endif %} {% if item.text %}
+			<div class="timeline__text">{{{item.text}}}</div>
+			{% endif %}
+		</li>
+		{% endfor %}
+	</ul>
+	{% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add education timeline section with configurable items
- document theme variables and usage
- include styles in global index

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ngx-platform/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6896ef91be3083339fea8df4c2ec912e