### PR TITLE
feat(template): add press logos feedback section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/feedback/press-logos/press-logos";

--- a/template/sections/feedback/press-logos/LICENSE
+++ b/template/sections/feedback/press-logos/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/feedback/press-logos/_press-logos.scss
+++ b/template/sections/feedback/press-logos/_press-logos.scss
@@ -1,0 +1,51 @@
+// press logos section
+
+.press-logos {
+        padding: calc(20px * var(--padding-scale)) 0;
+        text-align: center;
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 24px;
+                font-weight: 600;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+                margin-bottom: calc(20px * var(--margin-scale));
+        }
+
+        &__list {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: calc(16px * var(--margin-scale));
+        }
+
+        &__item {
+                padding: calc(8px * var(--padding-scale));
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                background-color: var(--c-bg-item);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                img {
+                        max-height: calc(2.5 * var(--icon-size));
+                        display: block;
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .press-logos__list {
+                gap: calc(12px * var(--margin-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .press-logos__list {
+                gap: calc(8px * var(--margin-scale));
+        }
+}

--- a/template/sections/feedback/press-logos/module.json
+++ b/template/sections/feedback/press-logos/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-feedback-press-logos.git" }

--- a/template/sections/feedback/press-logos/press-logos.html
+++ b/template/sections/feedback/press-logos/press-logos.html
@@ -1,0 +1,12 @@
+<div class="press-logos">
+        {% if section.title %}
+        <div class="press-logos__title">{{{section.title}}}</div>
+        {% endif %}
+        <div class="press-logos__list">
+                {% for logo in section.logos %}
+                <div class="press-logos__item">
+                        <img src="{{{logo.img}}}" alt="{{{logo.alt}}}" />
+                </div>
+                {% endfor %}
+        </div>
+</div>

--- a/template/sections/feedback/press-logos/readme.MD
+++ b/template/sections/feedback/press-logos/readme.MD
@@ -1,0 +1,69 @@
+# 📂 Press Logos `/sections/feedback/press-logos`
+
+Displays media or press logos, optionally with a section title. Useful for showcasing publications where a product or company has been featured.
+
+## ✅ Features
+
+-   Optional section title
+-   Renders a list of press logos
+-   Responsive layout with wrapping and spacing
+-   Uses global CSS variables for theming
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/feedback/press-logos/press-logos.html",
+        "title": "As seen in",
+        "logos": [
+                { "img": "/img/press/nyt.svg", "alt": "New York Times" },
+                { "img": "/img/press/forbes.svg", "alt": "Forbes" }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="press-logos">
+        {% if section.title %}
+        <div class="press-logos__title">{{{section.title}}}</div>
+        {% endif %}
+        <div class="press-logos__list">
+                {% for logo in section.logos %}
+                <div class="press-logos__item">
+                        <img src="{{{logo.img}}}" alt="{{{logo.alt}}}" />
+                </div>
+                {% endfor %}
+        </div>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Title uses `--ff-title`, `--c-text-primary`, and spacing variables for consistent typography
+-   Logos are displayed in a flex container that wraps and centers the items
+-   Logo containers use `--c-border`, `--c-bg-item`, and `--b-radius`
+-   Spacing scales with `--margin-scale` and `--padding-scale`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable             | Description                              |
+| -------------------- | ---------------------------------------- |
+| `--padding-scale`    | Vertical padding for section and items   |
+| `--margin-scale`     | Gap between logo items and title spacing |
+| `--ff-title`         | Font family for the title                |
+| `--c-text-primary`   | Title text color                         |
+| `--c-border`         | Border color of logo container           |
+| `--c-bg-item`        | Background color for logo container      |
+| `--b-radius`         | Rounds the logo container corners        |
+| `--icon-size`        | Base size used for logo height           |
+| `--bp-md`, `--bp-sm` | Breakpoints adjusting responsive spacing |
+
+---


### PR DESCRIPTION
## Summary
- add press logos section with optional title and logo list
- style press logos with CSS variables and responsive layout
- register press logos styles in global index

## Testing
- `npx sass --version` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_6896ef9f0af48333be989488308cbc78