### PR TITLE
feat(feedback): add trust badges section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/feedback/trust-badges/trust-badges";

--- a/template/sections/feedback/trust-badges/LICENSE
+++ b/template/sections/feedback/trust-badges/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/feedback/trust-badges/_trust-badges.scss
+++ b/template/sections/feedback/trust-badges/_trust-badges.scss
@@ -1,0 +1,42 @@
+// trust badges section
+
+.trust-badges {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: calc(24px * var(--margin-scale));
+        padding: calc(20px * var(--padding-scale)) 0;
+
+        &__item {
+                padding: calc(8px * var(--padding-scale));
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                background-color: var(--c-bg-item);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                filter: grayscale(100%);
+                transition: filter var(--transition);
+
+                img {
+                        max-height: calc(3 * var(--icon-size));
+                        display: block;
+                }
+
+                &:hover {
+                        filter: grayscale(0%);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .trust-badges {
+                gap: calc(16px * var(--margin-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .trust-badges {
+                gap: calc(12px * var(--margin-scale));
+        }
+}

--- a/template/sections/feedback/trust-badges/module.json
+++ b/template/sections/feedback/trust-badges/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-feedback-trust-badges.git" }

--- a/template/sections/feedback/trust-badges/readme.MD
+++ b/template/sections/feedback/trust-badges/readme.MD
@@ -1,0 +1,67 @@
+# 📂 Trust Badges `/sections/feedback/trust-badges`
+
+Displays a row of trust badges or certifications to build credibility. Each badge can optionally link to an external page.
+
+## ✅ Features
+
+-   Renders a list of trust badges
+-   Optional links per badge
+-   Responsive layout with wrapping and spacing
+-   Uses global CSS variables for theming
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/feedback/trust-badges/trust-badges.html",
+        "badges": [
+                { "img": "/img/badges/secure.svg", "alt": "Secure" },
+                { "href": "https://example.com", "img": "/img/badges/ssl.svg", "alt": "SSL" }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="trust-badges">
+        {% for badge in section.badges %}
+        <div class="trust-badges__item">
+                {% if badge.href %}
+                <a href="{{{badge.href}}}"><img src="{{{badge.img}}}" alt="{{{badge.alt}}}" /></a>
+                {% else %}
+                <img src="{{{badge.img}}}" alt="{{{badge.alt}}}" />
+                {% endif %}
+        </div>
+        {% endfor %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses flexbox to center and wrap badges
+-   Spacing scales with `--margin-scale` and `--padding-scale`
+-   Badge containers leverage `--c-border`, `--c-bg-item`, `--b-radius`
+-   Grayscale effect removed on hover using `--transition`
+-   Badge height derives from `--icon-size` for consistent sizing
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable             | Description                              |
+| -------------------- | ---------------------------------------- |
+| `--margin-scale`     | Controls gap between badges              |
+| `--padding-scale`    | Padding around each badge                |
+| `--c-border`         | Border color of badge container          |
+| `--c-bg-item`        | Background color for badge container     |
+| `--b-radius`         | Rounds badge container corners           |
+| `--icon-size`        | Base size used for badge height          |
+| `--transition`       | Transition for hover grayscale effect    |
+| `--bp-md`, `--bp-sm` | Breakpoints adjusting responsive spacing |
+
+---

--- a/template/sections/feedback/trust-badges/trust-badges.html
+++ b/template/sections/feedback/trust-badges/trust-badges.html
@@ -1,0 +1,11 @@
+<div class="trust-badges">
+        {% for badge in section.badges %}
+        <div class="trust-badges__item">
+                {% if badge.href %}
+                <a href="{{{badge.href}}}"><img src="{{{badge.img}}}" alt="{{{badge.alt}}}" /></a>
+                {% else %}
+                <img src="{{{badge.img}}}" alt="{{{badge.alt}}}" />
+                {% endif %}
+        </div>
+        {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- add reusable trust badges section with responsive layout
- document schema and styling for trust badges
- register trust badges styles in main index SCSS

## Testing
- No tests available

------
https://chatgpt.com/codex/tasks/task_e_6896efca03e08333815ea7ad80038101