### PR TITLE
feat(forms): add rsvp form section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/forms/rsvp/rsvp";

--- a/template/sections/forms/rsvp/LICENSE
+++ b/template/sections/forms/rsvp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/forms/rsvp/_rsvp.scss
+++ b/template/sections/forms/rsvp/_rsvp.scss
@@ -1,0 +1,115 @@
+// rsvp section
+
+.rsvp {
+        padding: calc(40px * var(--padding-scale)) 0;
+        text-align: center;
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                margin-top: calc(12px * var(--margin-scale));
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                max-width: 70ch;
+                margin-left: auto;
+                margin-right: auto;
+        }
+
+        &__form {
+                margin-top: calc(20px * var(--margin-scale));
+                display: grid;
+                gap: calc(12px * var(--margin-scale));
+                max-width: 480px;
+                margin-left: auto;
+                margin-right: auto;
+        }
+
+        &__field {
+                text-align: left;
+        }
+
+        &__label {
+                display: block;
+                margin-bottom: calc(4px * var(--margin-scale));
+                font-size: calc(var(--font-size) * 0.9);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__input,
+        &__select {
+                width: 100%;
+                padding: calc(8px * var(--padding-scale))
+                        calc(12px * var(--padding-scale));
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                background-color: var(--c-bg-item);
+                color: var(--c-text-secondary);
+                transition: border-color var(--transition),
+                        background-color var(--transition);
+                &::placeholder {
+                        color: var(--c-placeholder);
+                }
+                &:focus {
+                        outline: none;
+                        border-color: var(--c-primary-border);
+                        background-color: var(--c-white);
+                }
+        }
+
+        &__button {
+                margin-top: calc(8px * var(--margin-scale));
+                padding: calc(10px * var(--padding-scale))
+                        calc(16px * var(--padding-scale));
+                font-size: var(--font-size);
+                font-family: var(--ff-base);
+                border: none;
+                border-radius: var(--b-radius);
+                background-color: var(--c-primary);
+                color: var(--c-text-primary);
+                cursor: pointer;
+                transition: background-color var(--transition);
+                &:hover {
+                        background-color: var(--c-primary-hover);
+                }
+                &:active {
+                        background-color: var(--c-primary-cursor);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .rsvp__title {
+                font-size: 28px;
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .rsvp__title {
+                font-size: 24px;
+        }
+        .rsvp__description {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .rsvp__title {
+                font-size: 20px;
+        }
+        .rsvp__description {
+                font-size: calc(var(--font-size) * 0.875);
+        }
+}

--- a/template/sections/forms/rsvp/module.json
+++ b/template/sections/forms/rsvp/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-forms-rsvp.git" }

--- a/template/sections/forms/rsvp/readme.MD
+++ b/template/sections/forms/rsvp/readme.MD
@@ -1,0 +1,95 @@
+# 📂 RSVP `/sections/forms/rsvp`
+
+RSVP form section for collecting attendee responses. Includes basic fields for name, email, and attendance choice, with customizable submit action and button text.
+
+## ✅ Features
+
+-   Optional title and description
+-   Centered, responsive form layout
+-   Accessible labels and inputs
+-   Styled via CSS variables for easy theming
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/forms/rsvp/rsvp.html",
+        "title": "RSVP",
+        "description": "Let us know if you can make it!",
+        "action": "/rsvp",
+        "buttonText": "Send"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="rsvp">
+        {% if section.title %}
+        <div class="rsvp__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="rsvp__description">{{{section.description}}}</div>
+        {% endif %}
+        <form class="rsvp__form" action="{{{section.action}}}" method="post">
+                <div class="rsvp__field">
+                        <label class="rsvp__label" for="rsvp-name">Name</label>
+                        <input class="rsvp__input" type="text" id="rsvp-name" name="name" required />
+                </div>
+                <div class="rsvp__field">
+                        <label class="rsvp__label" for="rsvp-email">Email</label>
+                        <input class="rsvp__input" type="email" id="rsvp-email" name="email" required />
+                </div>
+                <div class="rsvp__field">
+                        <label class="rsvp__label" for="rsvp-attending">Attending</label>
+                        <select class="rsvp__select" id="rsvp-attending" name="attending">
+                                <option value="yes">Yes</option>
+                                <option value="no">No</option>
+                        </select>
+                </div>
+                <button class="rsvp__button" type="submit">{{{section.buttonText}}}</button>
+        </form>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Spacing scales with `--padding-scale` and `--margin-scale`
+-   Form inputs and buttons inherit global typography and color variables
+-   Inputs highlight using `--c-primary-border` on focus
+-   Responsive typography adjusts at configured breakpoints
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                |
+| ------------------------------- | ------------------------------------------ |
+| `--padding-scale`               | Controls section and input padding         |
+| `--margin-scale`                | Spacing between elements                   |
+| `--font-size`                   | Base font size for text and inputs         |
+| `--line-height`                 | Line height for all text                   |
+| `--letter-spacing`              | Applied to title and description           |
+| `--ff-base`                     | Font for form text                         |
+| `--ff-title`                    | Font for section title                     |
+| `--b-radius`                    | Rounds inputs and button                   |
+| `--c-border`                    | Default border color for inputs            |
+| `--c-bg-item`                   | Background color of input fields           |
+| `--c-placeholder`              | Placeholder text color                     |
+| `--c-text-secondary`            | Input text color                           |
+| `--c-text-primary`              | Title and button text color                |
+| `--c-text-body-secondary`       | Description text color                     |
+| `--c-primary`                   | Button background color                    |
+| `--c-primary-hover`             | Button hover state                         |
+| `--c-primary-cursor`            | Button active state                        |
+| `--c-primary-border`            | Input border color on focus                |
+| `--transition`                  | Transition timing for interactive states   |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Breakpoints for responsive adjustments     |
+
+---

--- a/template/sections/forms/rsvp/rsvp.html
+++ b/template/sections/forms/rsvp/rsvp.html
@@ -1,0 +1,26 @@
+<div class="rsvp">
+        {% if section.title %}
+        <div class="rsvp__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="rsvp__description">{{{section.description}}}</div>
+        {% endif %}
+        <form class="rsvp__form" action="{{{section.action}}}" method="post">
+                <div class="rsvp__field">
+                        <label class="rsvp__label" for="rsvp-name">Name</label>
+                        <input class="rsvp__input" type="text" id="rsvp-name" name="name" required />
+                </div>
+                <div class="rsvp__field">
+                        <label class="rsvp__label" for="rsvp-email">Email</label>
+                        <input class="rsvp__input" type="email" id="rsvp-email" name="email" required />
+                </div>
+                <div class="rsvp__field">
+                        <label class="rsvp__label" for="rsvp-attending">Attending</label>
+                        <select class="rsvp__select" id="rsvp-attending" name="attending">
+                                <option value="yes">Yes</option>
+                                <option value="no">No</option>
+                        </select>
+                </div>
+                <button class="rsvp__button" type="submit">{{{section.buttonText}}}</button>
+        </form>
+</div>


### PR DESCRIPTION
## Summary
- add RSVP form section with HTML, SCSS, module metadata, and docs
- integrate section styles into global index.scss

## Testing
- `npx sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896f108d9d08333bf2629816c5ef1d6