### PR TITLE
feat: add background layout section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,12 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.background {
+        padding: calc(40px * var(--padding-scale)) calc(20px * var(--padding-scale));
+        color: var(--c-text-primary);
+        background-color: var(--c-body);
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-position: center;
+        transition: background-color var(--transition);
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/layout/background/background";

--- a/template/sections/layout/background/LICENSE
+++ b/template/sections/layout/background/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/layout/background/_background.scss
+++ b/template/sections/layout/background/_background.scss
@@ -1,0 +1,10 @@
+// background section
+.background {
+        padding: calc(40px * var(--padding-scale)) calc(20px * var(--padding-scale));
+        color: var(--c-text-primary);
+        background-color: var(--c-body);
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-position: center;
+        transition: background-color var(--transition);
+}

--- a/template/sections/layout/background/background.html
+++ b/template/sections/layout/background/background.html
@@ -1,0 +1,8 @@
+<div class="background"
+        {% if section.color or section.image or section.size or section.position %}
+        style="{% if section.color %}background-color: {{{section.color}}};{% endif %}{% if section.image %} background-image: url('{{{section.image}}}');{% endif %}{% if section.size %} background-size: {{{section.size}}};{% endif %}{% if section.position %} background-position: {{{section.position}}};{% endif %}"
+        {% endif %}>
+        {% if section.content %}
+        {{{section.content}}}
+        {% endif %}
+</div>

--- a/template/sections/layout/background/module.json
+++ b/template/sections/layout/background/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-layout-background.git" }

--- a/template/sections/layout/background/readme.MD
+++ b/template/sections/layout/background/readme.MD
@@ -1,0 +1,60 @@
+# 📂 Background `/sections/layout/background`
+
+Utility section to wrap content with a customizable background color or image.
+
+## ✅ Features
+
+-   Optional background color via `section.color`
+-   Optional background image via `section.image`
+-   Supports custom background size and position
+-   Uses CSS variables for spacing, colors, and transitions
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/layout/background/background.html",
+        "color": "#000000", // optional background color
+        "image": "/img/bg.jpg", // optional background image
+        "size": "cover", // optional background-size value
+        "position": "center", // optional background-position value
+        "content": "<h2>Wrapped Content</h2>" // optional inner HTML
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="background"
+        {% if section.color or section.image or section.size or section.position %}
+        style="{% if section.color %}background-color: {{{section.color}}};{% endif %}{% if section.image %} background-image: url('{{{section.image}}}');{% endif %}{% if section.size %} background-size: {{{section.size}}};{% endif %}{% if section.position %} background-position: {{{section.position}}};{% endif %}"
+        {% endif %}>
+        {% if section.content %}
+        {{{section.content}}}
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Padding scales with `--padding-scale`
+-   Text inherits `--c-text-primary`
+-   Default background color uses `--c-body`
+-   Background transitions follow `--transition`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable             | Description                        |
+| -------------------- | ---------------------------------- |
+| `--padding-scale`    | Controls section padding           |
+| `--c-text-primary`   | Text color inside background block |
+| `--c-body`           | Default background color           |
+| `--transition`       | Background color transition        |
+
+---


### PR DESCRIPTION
## Summary
- add background layout section with optional color, image, size and position
- document background section and include SCSS import

## Testing
- `npm install -g sass` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896f206b9988333acd3574bbc431aff