### PR TITLE
feat: add layout divider section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/layout/divider/divider";

--- a/template/sections/layout/divider/LICENSE
+++ b/template/sections/layout/divider/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/layout/divider/_divider.scss
+++ b/template/sections/layout/divider/_divider.scss
@@ -1,0 +1,34 @@
+// divider section
+
+.divider {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        font-family: var(--ff-base);
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-secondary);
+        margin: calc(24px * var(--margin-scale)) 0;
+
+        &::before,
+        &::after {
+                content: "";
+                flex: 1 1 auto;
+                border-bottom: 1px solid var(--c-border);
+        }
+
+        &:not(:empty)::before {
+                margin-right: calc(12px * var(--margin-scale));
+        }
+
+        &:not(:empty)::after {
+                margin-left: calc(12px * var(--margin-scale));
+        }
+
+        &__text {
+                display: inline-block;
+        }
+}

--- a/template/sections/layout/divider/divider.html
+++ b/template/sections/layout/divider/divider.html
@@ -1,0 +1,5 @@
+<div class="divider">
+        {% if section.text %}
+        <span class="divider__text">{{{section.text}}}</span>
+        {% endif %}
+</div>

--- a/template/sections/layout/divider/module.json
+++ b/template/sections/layout/divider/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-layout-divider.git" }

--- a/template/sections/layout/divider/readme.MD
+++ b/template/sections/layout/divider/readme.MD
@@ -1,0 +1,55 @@
+# \ud83d\udcc2 Divider `/sections/layout/divider`
+
+Horizontal divider used to separate content blocks with optional centered text.
+
+## \u2705 Features
+
+-   Optional text centered between lines
+-   Uses CSS variables for spacing, color, and typography
+-   Responsive spacing via design tokens
+
+---
+
+## \ud83d\uddfe Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/layout/divider/divider.html",
+        "text": "Optional divider text"
+}
+```
+
+## \ud83d\udea7 HTML Structure
+
+```html
+<div class="divider">
+        {% if section.text %}
+        <span class="divider__text">{{{section.text}}}</span>
+        {% endif %}
+</div>
+```
+
+---
+
+## \ud83c\udfa8 Styling Notes
+
+-   Divider lines use `--c-border`
+-   Text color inherits from `--c-text-secondary`
+-   Font styles rely on `--ff-base`, `--font-size`, `--line-height`, and `--letter-spacing`
+-   Vertical spacing controlled by `--margin-scale`
+
+---
+
+## \ud83e\udde9 Theme Variables Used (from `template.json`)
+
+| Variable              | Description                 |
+| --------------------- | --------------------------- |
+| `--c-border`          | Divider line color          |
+| `--c-text-secondary`  | Divider text color          |
+| `--ff-base`           | Base font family            |
+| `--font-size`         | Base font size              |
+| `--line-height`       | Default line height         |
+| `--letter-spacing`    | Default letter spacing      |
+| `--margin-scale`      | Controls divider spacing    |


### PR DESCRIPTION
## Summary
- add layout divider component with optional centered text
- document divider usage and styling variables
- wire divider styles into template stylesheet

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f943cd4c833398a63919b77209c8