### PR TITLE
feat: add layout grid section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/layout/grid/grid";

--- a/template/sections/layout/grid/LICENSE
+++ b/template/sections/layout/grid/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/layout/grid/_grid.scss
+++ b/template/sections/layout/grid/_grid.scss
@@ -1,0 +1,14 @@
+// grid section
+
+.grid {
+        padding-bottom: calc(50px * var(--padding-scale));
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(var(--grid-min, 280px), 1fr));
+        gap: calc(20px * var(--margin-scale));
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .grid {
+                grid-template-columns: 1fr;
+        }
+}

--- a/template/sections/layout/grid/grid.html
+++ b/template/sections/layout/grid/grid.html
@@ -1,0 +1,7 @@
+<div class="grid"{% if section.min %} style="--grid-min: {{{section.min}}};"{% endif %}>
+        {% if section.items %}
+        {% for item in section.items %}
+        <div class="grid__item">{{{item.content}}}</div>
+        {% endfor %}
+        {% endif %}
+</div>

--- a/template/sections/layout/grid/module.json
+++ b/template/sections/layout/grid/module.json
@@ -1,0 +1,3 @@
+{
+  "repo": "https://github.com/WebArtWork/wjst-section-layout-grid.git"
+}

--- a/template/sections/layout/grid/readme.MD
+++ b/template/sections/layout/grid/readme.MD
@@ -1,0 +1,53 @@
+# 📂 Grid `/sections/layout/grid`
+
+Responsive multi-column layout utility built with CSS Grid. Renders an array of items and adapts to different screen sizes.
+
+## ✅ Features
+
+-   Responsive grid layout using CSS Grid
+-   Adjustable minimum column width via the `section.min` option
+-   Gap and spacing controlled by global CSS variables
+-   Collapses to a single column below the `--bp-sm` breakpoint
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+  "src": "/sections/layout/grid/grid.html",
+  "min": "200px",
+  "items": [
+    { "content": "<div>First item</div>" },
+    { "content": "<div>Second item</div>" }
+  ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="grid" style="--grid-min: {{{section.min}}};">
+        {% for item in section.items %}
+        <div class="grid__item">{{{item.content}}}</div>
+        {% endfor %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses `display: grid` with `repeat(auto-fit, minmax())` for responsive columns
+-   Bottom padding and item gaps respect `--padding-scale` and `--margin-scale`
+-   Custom minimum width set with the `--grid-min` CSS variable
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable          | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `--padding-scale` | Controls bottom padding                           |
+| `--margin-scale`  | Gap between grid items                            |
+| `--bp-sm`         | Breakpoint at which grid becomes a single column  |


### PR DESCRIPTION
## Summary
- add responsive layout grid section with SCSS, HTML, docs, and module metadata
- wire grid styles into global index.scss

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f96aed248333b93a11b406ae2642