### PR TITLE
feat: add social share utility section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/utility/social-share/social-share";

--- a/template/sections/utility/social-share/LICENSE
+++ b/template/sections/utility/social-share/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/utility/social-share/_social-share.scss
+++ b/template/sections/utility/social-share/_social-share.scss
@@ -1,0 +1,44 @@
+// social-share section
+
+.social-share {
+        display: flex;
+        gap: calc(12px * var(--margin-scale));
+        align-items: center;
+
+        &__link {
+                display: inline-flex;
+                width: calc(var(--icon-size) * 2);
+                height: calc(var(--icon-size) * 2);
+                transition: opacity var(--transition);
+
+                img {
+                        width: 100%;
+                        height: 100%;
+                        display: block;
+                }
+
+                &:hover {
+                        opacity: 0.8;
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .social-share {
+                gap: calc(8px * var(--margin-scale));
+        }
+        .social-share__link {
+                width: calc(var(--icon-size) * 1.5);
+                height: calc(var(--icon-size) * 1.5);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .social-share {
+                gap: calc(6px * var(--margin-scale));
+        }
+        .social-share__link {
+                width: calc(var(--icon-size) * 1.25);
+                height: calc(var(--icon-size) * 1.25);
+        }
+}

--- a/template/sections/utility/social-share/module.json
+++ b/template/sections/utility/social-share/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-utility-social-share.git" }

--- a/template/sections/utility/social-share/readme.MD
+++ b/template/sections/utility/social-share/readme.MD
@@ -1,0 +1,51 @@
+# 📂 Social Share `/sections/utility/social-share`
+
+Utility section that renders a row of social network buttons for sharing the current page.
+Each button links to the respective network's share endpoint.
+
+## ✅ Features
+
+-   Supports Facebook, LinkedIn and Telegram share links
+-   Network list configurable via `section.networks`
+-   Buttons resize and space responsively using CSS variables
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/utility/social-share/social-share.html",
+        "url": "https://example.com/page",
+        "networks": ["facebook", "linkedin", "telegram"]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="social-share">
+        {% for network in section.networks %}
+        <!-- Conditional anchors rendered per network -->
+        {% endfor %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses `gap` and icon sizing scaled by `--margin-scale` and `--icon-size`
+-   Hover state driven by `--transition`
+-   Layout adjusts at `--bp-md` and `--bp-sm` breakpoints
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable            | Description                              |
+| ------------------- | ---------------------------------------- |
+| `--icon-size`       | Base size for share icons                 |
+| `--margin-scale`    | Controls spacing between icons            |
+| `--transition`      | Hover animation timing                   |
+| `--bp-md`, `--bp-sm`| Responsive breakpoints for layout tweaks |

--- a/template/sections/utility/social-share/social-share.html
+++ b/template/sections/utility/social-share/social-share.html
@@ -1,0 +1,35 @@
+<div class="social-share">
+        {% for network in section.networks %}
+                {% if network == 'facebook' %}
+                <a
+                        href="https://www.facebook.com/sharer/sharer.php?u={{{section.url}}}"
+                        class="social-share__link social-share__facebook"
+                        target="_blank"
+                        rel="noopener"
+                        aria-label="Share on Facebook"
+                >
+                        <img src="/img/fb.svg" alt="facebook" />
+                </a>
+                {% elseif network == 'linkedin' %}
+                <a
+                        href="https://www.linkedin.com/sharing/share-offsite/?url={{{section.url}}}"
+                        class="social-share__link social-share__linkedin"
+                        target="_blank"
+                        rel="noopener"
+                        aria-label="Share on LinkedIn"
+                >
+                        <img src="/img/in.svg" alt="linkedin" />
+                </a>
+                {% elseif network == 'telegram' %}
+                <a
+                        href="https://t.me/share/url?url={{{section.url}}}"
+                        class="social-share__link social-share__telegram"
+                        target="_blank"
+                        rel="noopener"
+                        aria-label="Share on Telegram"
+                >
+                        <img src="/img/tg.svg" alt="telegram" />
+                </a>
+                {% endif %}
+        {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- add configurable utility social-share section with share links for Facebook, LinkedIn, and Telegram
- document usage and theme variables for social-share section
- integrate social-share styles into global stylesheet

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fda64c0c8333898c768015578865