### PR TITLE
feat: add notification utility section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/utility/notification/notification";

--- a/template/sections/utility/notification/LICENSE
+++ b/template/sections/utility/notification/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/utility/notification/_notification.scss
+++ b/template/sections/utility/notification/_notification.scss
@@ -1,0 +1,70 @@
+// notification section
+
+.notification {
+        position: relative;
+        padding: calc(16px * var(--padding-scale));
+        border-left: 4px solid var(--c-primary);
+        background: var(--c-bg-item);
+        color: var(--c-text-primary);
+        font-family: var(--ff-base);
+        display: flex;
+        align-items: center;
+
+        &__message {
+                margin-right: calc(20px * var(--margin-scale));
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                flex: 1;
+        }
+
+        &__close {
+                position: absolute;
+                top: calc(8px * var(--padding-scale));
+                right: calc(8px * var(--padding-scale));
+                background: none;
+                border: none;
+                cursor: pointer;
+                color: inherit;
+                font-size: calc(var(--font-size) * 1.25);
+                line-height: 1;
+                transition: color var(--transition);
+
+                &:hover {
+                        color: var(--c-primary-hover);
+                }
+        }
+
+        &--success {
+                border-color: var(--c-success);
+                background: var(--c-success);
+        }
+
+        &--error {
+                border-color: var(--c-error);
+                background: var(--c-error);
+        }
+
+        &--alert {
+                border-color: var(--c-alert);
+                background: var(--c-alert);
+        }
+
+        &--hidden {
+                display: none;
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .notification {
+                padding: calc(12px * var(--padding-scale));
+                &__message {
+                        font-size: calc(var(--font-size) * 0.95);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .notification__message {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}

--- a/template/sections/utility/notification/module.json
+++ b/template/sections/utility/notification/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-utility-notification.git" }

--- a/template/sections/utility/notification/notification.html
+++ b/template/sections/utility/notification/notification.html
@@ -1,0 +1,15 @@
+<div class="notification{% if section.type %} notification--{{{section.type}}}{% endif %}" data-notification>
+        <div class="notification__message">{{{section.message}}}</div>
+        <button class="notification__close" aria-label="Close notification">&times;</button>
+</div>
+<script>
+        (function () {
+                document.querySelectorAll('[data-notification]').forEach(function (el) {
+                        var close = el.querySelector('.notification__close');
+                        if (!close) return;
+                        close.addEventListener('click', function () {
+                                el.classList.add('notification--hidden');
+                        });
+                });
+        })();
+</script>

--- a/template/sections/utility/notification/readme.MD
+++ b/template/sections/utility/notification/readme.MD
@@ -1,0 +1,76 @@
+# 📂 Notification `/sections/utility/notification`
+
+Dismissible notification banner for displaying contextual messages. Supports success, error, and alert variants.
+
+## ✅ Features
+
+-   Optional message and type (success, error, alert)
+-   Close button to dismiss the notification
+-   Responsive typography and spacing
+-   Uses CSS variables for theme customization
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/utility/notification/notification.html",
+        "message": "Site will undergo maintenance tonight",
+        "type": "alert"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="notification{% if section.type %} notification--{{{section.type}}}{% endif %}" data-notification>
+        <div class="notification__message">{{{section.message}}}</div>
+        <button class="notification__close" aria-label="Close notification">&times;</button>
+</div>
+<script>
+        (function () {
+                document.querySelectorAll('[data-notification]').forEach(function (el) {
+                        var close = el.querySelector('.notification__close');
+                        if (!close) return;
+                        close.addEventListener('click', function () {
+                                el.classList.add('notification--hidden');
+                        });
+                });
+        })();
+</script>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Notification uses `border-left` to indicate variant color
+-   Background and text colors inherit from CSS variables
+-   Close button uses `--transition` for hover effects
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                  | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--padding-scale`         | Controls banner padding                          |
+| `--margin-scale`          | Spacing around elements                          |
+| `--font-size`             | Base message font size                           |
+| `--line-height`           | Line height for message                          |
+| `--ff-base`               | Font family for notification text               |
+| `--transition`            | Transition for close button hover                |
+| `--c-primary`             | Default border color                             |
+| `--c-bg-item`             | Background color for default notification        |
+| `--c-text-primary`        | Text color                                       |
+| `--c-primary-hover`       | Close button hover color                         |
+| `--c-success`             | Success variant background/border                |
+| `--c-error`               | Error variant background/border                  |
+| `--c-alert`               | Alert variant background/border                  |
+| `--c-border`              | Border color for default notification            |
+| `--bp-md`, `--bp-sm`      | Breakpoints for responsive sizing                |
+
+---


### PR DESCRIPTION
## Summary
- add utility notification section with dismissible logic and theme-aware styles
- document section schema and styling variables
- register notification styles in global SCSS index

## Testing
- `npx sass template/css/index.scss /tmp/index.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896fd7ae62c83338864bb7d28261076