### PR TITLE
feat: add language switcher section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/utility/language-switcher/language-switcher";

--- a/template/sections/utility/language-switcher/LICENSE
+++ b/template/sections/utility/language-switcher/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/utility/language-switcher/_language-switcher.scss
+++ b/template/sections/utility/language-switcher/_language-switcher.scss
@@ -1,0 +1,39 @@
+// language switcher section
+
+.language-switcher {
+        display: inline-flex;
+        align-items: center;
+        gap: calc(8px * var(--padding-scale));
+        font-family: var(--ff-base);
+
+        &__label {
+                font-size: calc(var(--font-size) * 0.9);
+                color: var(--c-text-secondary);
+        }
+
+        &__select {
+                font-family: var(--ff-base);
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                padding: calc(6px * var(--padding-scale))
+                        calc(8px * var(--padding-scale));
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                background-color: var(--c-bg-item);
+                color: var(--c-text-primary);
+                cursor: pointer;
+                transition: border-color var(--transition), box-shadow var(--transition);
+
+                &:focus {
+                        outline: none;
+                        border-color: var(--c-primary);
+                        box-shadow: 0 0 0 2px var(--c-primary-border);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .language-switcher__label {
+                font-size: calc(var(--font-size) * 0.8);
+        }
+}

--- a/template/sections/utility/language-switcher/language-switcher.html
+++ b/template/sections/utility/language-switcher/language-switcher.html
@@ -1,0 +1,20 @@
+<div class="language-switcher">
+        {% if section.label %}
+        <label for="language-switcher__select" class="language-switcher__label">
+                {{{section.label}}}
+        </label>
+        {% endif %}
+        {% if section.languages %}
+        <select
+                id="language-switcher__select"
+                class="language-switcher__select"
+                onchange="if(this.value){window.location.href=this.value}"
+        >
+                {% for l in section.languages %}
+                <option value="{{{l.url}}}" {% if l.current %}selected{% endif %}>
+                        {{{l.label}}}
+                </option>
+                {% endfor %}
+        </select>
+        {% endif %}
+</div>

--- a/template/sections/utility/language-switcher/module.json
+++ b/template/sections/utility/language-switcher/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-utility-language-switcher.git" }

--- a/template/sections/utility/language-switcher/readme.MD
+++ b/template/sections/utility/language-switcher/readme.MD
@@ -1,0 +1,81 @@
+# 📂 Language Switcher `/sections/utility/language-switcher`
+
+A small utility section that lets users switch between site languages. Renders an optional label and a `<select>` populated from a list of languages. When a new language is selected, the page redirects to the corresponding URL.
+
+## ✅ Features
+
+-   Optional label via `section.label`
+-   Dynamically generates `<option>` items from `section.languages`
+-   Redirects on change using the option's URL
+-   Fully themeable with global CSS variables
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/utility/language-switcher/language-switcher.html",
+        "label": "Language",
+        "languages": [
+                { "label": "English", "url": "/en", "current": true },
+                { "label": "Español", "url": "/es" }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="language-switcher">
+        {% if section.label %}
+        <label for="language-switcher__select" class="language-switcher__label">
+                {{{section.label}}}
+        </label>
+        {% endif %}
+        {% if section.languages %}
+        <select
+                id="language-switcher__select"
+                class="language-switcher__select"
+                onchange="if(this.value){window.location.href=this.value}"
+        >
+                {% for l in section.languages %}
+                <option value="{{{l.url}}}" {% if l.current %}selected{% endif %}>
+                        {{{l.label}}}
+                </option>
+                {% endfor %}
+        </select>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Spacing and sizing scale with `--padding-scale` and `--font-size`
+-   Label and select use `--ff-base` and `--line-height`
+-   Colors derive from `--c-text-primary`, `--c-text-secondary`, `--c-bg-item`, and `--c-border`
+-   Focus state leverages `--c-primary` and `--c-primary-border`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable             | Description                               |
+| -------------------- | ----------------------------------------- |
+| `--padding-scale`    | Scales gaps and select padding            |
+| `--font-size`        | Base font size for label and select       |
+| `--line-height`      | Line height for select                    |
+| `--ff-base`          | Font family for label and select          |
+| `--c-text-primary`   | Text color inside the select              |
+| `--c-text-secondary` | Text color for the label                  |
+| `--c-bg-item`        | Background color of the select            |
+| `--c-border`         | Border color of the select                |
+| `--b-radius`         | Border radius for the select              |
+| `--transition`       | Transition for border and box-shadow      |
+| `--c-primary`        | Focus border color                        |
+| `--c-primary-border` | Focus outline color                       |
+| `--bp-sm`            | Breakpoint for label font-size adjustment |


### PR DESCRIPTION
## Summary
- add utility language-switcher section with markup, styles and docs
- wire up section stylesheet in global index

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fd6c5cbc8333a0e59f87098fd3d6