### PR TITLE
feat: add cookie banner utility section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/utility/cookie-banner/cookie-banner";

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -8,10 +8,18 @@ const toggleClass = (id, className) => {
 };
 
 const toTop = () => {
-	window.scrollTo({
-		top: 0,
-		behavior: "smooth",
-	});
+        window.scrollTo({
+                top: 0,
+                behavior: "smooth",
+        });
+};
+
+const acceptCookies = () => {
+        document.cookie = "cookiesAccepted=true; max-age=31536000; path=/";
+        const banner = document.getElementById("cookieBanner");
+        if (banner) {
+                banner.classList.add("hidden");
+        }
 };
 
 const sidebar = {};
@@ -152,10 +160,10 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 document.addEventListener("DOMContentLoaded", () => {
-	document.querySelectorAll(".variant-selector").forEach((selector) => {
-		const options = selector.querySelectorAll(".variant-selector__option");
-		const img = selector.querySelector(".variant-selector__image");
-		const price = selector.querySelector(".variant-selector__price");
+        document.querySelectorAll(".variant-selector").forEach((selector) => {
+                const options = selector.querySelectorAll(".variant-selector__option");
+                const img = selector.querySelector(".variant-selector__image");
+                const price = selector.querySelector(".variant-selector__price");
 
 		const setActive = (option) => {
 			options.forEach((o) =>
@@ -178,35 +186,44 @@ document.addEventListener("DOMContentLoaded", () => {
 		});
 	});
 
-	const sections = document.querySelectorAll(".add-to-cart");
-	if (!sections.length) {
-		return;
-	}
+        const sections = document.querySelectorAll(".add-to-cart");
+        if (!sections.length) {
+                return;
+        }
 
-	let cartCount = 0;
-	const cartCounter = document.querySelector("[data-cart-count]");
+        let cartCount = 0;
+        const cartCounter = document.querySelector("[data-cart-count]");
 
-	sections.forEach((section) => {
-		const qtyInput = section.querySelector(".add-to-cart__quantity");
-		const decBtn = section.querySelector(".add-to-cart__btn--decrease");
-		const incBtn = section.querySelector(".add-to-cart__btn--increase");
-		const submitBtn = section.querySelector(".add-to-cart__submit");
+        sections.forEach((section) => {
+                const qtyInput = section.querySelector(".add-to-cart__quantity");
+                const decBtn = section.querySelector(".add-to-cart__btn--decrease");
+                const incBtn = section.querySelector(".add-to-cart__btn--increase");
+                const submitBtn = section.querySelector(".add-to-cart__submit");
 
-		const updateQty = (delta) => {
-			const current = parseInt(qtyInput.value, 10) || 1;
-			const next = Math.max(1, current + delta);
-			qtyInput.value = next;
-		};
+                const updateQty = (delta) => {
+                        const current = parseInt(qtyInput.value, 10) || 1;
+                        const next = Math.max(1, current + delta);
+                        qtyInput.value = next;
+                };
 
-		decBtn.addEventListener("click", () => updateQty(-1));
-		incBtn.addEventListener("click", () => updateQty(1));
+                decBtn.addEventListener("click", () => updateQty(-1));
+                incBtn.addEventListener("click", () => updateQty(1));
 
-		submitBtn.addEventListener("click", () => {
-			const qty = parseInt(qtyInput.value, 10) || 1;
-			cartCount += qty;
-			if (cartCounter) {
-				cartCounter.textContent = cartCount;
-			}
-		});
-	});
+                submitBtn.addEventListener("click", () => {
+                        const qty = parseInt(qtyInput.value, 10) || 1;
+                        cartCount += qty;
+                        if (cartCounter) {
+                                cartCounter.textContent = cartCount;
+                        }
+                });
+        });
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+        if (document.cookie.includes("cookiesAccepted=true")) {
+                const banner = document.getElementById("cookieBanner");
+                if (banner) {
+                        banner.classList.add("hidden");
+                }
+        }
 });

--- a/template/sections/utility/cookie-banner/LICENSE
+++ b/template/sections/utility/cookie-banner/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/utility/cookie-banner/_cookie-banner.scss
+++ b/template/sections/utility/cookie-banner/_cookie-banner.scss
@@ -1,0 +1,81 @@
+// cookie banner section
+
+.cookie-banner {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        background-color: var(--c-secondary);
+        color: var(--c-text-primary);
+        padding: calc(10px * var(--padding-scale)) calc(20px * var(--padding-scale));
+        display: flex;
+        align-items: center;
+        font-family: var(--ff-base);
+        box-shadow: 0 -2px 8px var(--c-shadow);
+        z-index: 1000;
+
+        &.hidden {
+                display: none;
+        }
+
+        &__content {
+                display: flex;
+                gap: calc(10px * var(--margin-scale));
+                flex-grow: 1;
+                align-items: center;
+        }
+
+        &__text {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+        }
+
+        &__link {
+                color: var(--c-primary);
+                text-decoration: underline;
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                transition: color var(--transition);
+
+                &:hover {
+                        color: var(--c-primary-hover);
+                }
+        }
+
+        &__button {
+                background-color: var(--c-primary);
+                color: var(--c-text-primary);
+                padding: calc(8px * var(--padding-scale)) calc(16px * var(--padding-scale));
+                border: none;
+                border-radius: var(--b-radius);
+                cursor: pointer;
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                transition: background-color var(--transition);
+
+                &:hover {
+                        background-color: var(--c-primary-hover);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .cookie-banner {
+                flex-direction: column;
+                align-items: stretch;
+
+                &__content {
+                        flex-direction: column;
+                        align-items: flex-start;
+                        gap: calc(8px * var(--margin-scale));
+                }
+
+                &__button {
+                        width: 100%;
+                        margin-top: calc(10px * var(--margin-scale));
+                }
+        }
+}

--- a/template/sections/utility/cookie-banner/cookie-banner.html
+++ b/template/sections/utility/cookie-banner/cookie-banner.html
@@ -1,0 +1,11 @@
+<div id="cookieBanner" class="cookie-banner">
+        <div class="cookie-banner__content">
+                <span class="cookie-banner__text">{{{section.text}}}</span>
+                {% if section.link %}
+                <a href="{{{section.link.url}}}" class="cookie-banner__link">{{{section.link.label}}}</a>
+                {% endif %}
+        </div>
+        <button class="cookie-banner__button" onclick="acceptCookies()">
+                {{{section.button}}}
+        </button>
+</div>

--- a/template/sections/utility/cookie-banner/module.json
+++ b/template/sections/utility/cookie-banner/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-utility-cookie-banner.git" }

--- a/template/sections/utility/cookie-banner/readme.MD
+++ b/template/sections/utility/cookie-banner/readme.MD
@@ -1,0 +1,63 @@
+# 📂 Cookie Banner `/sections/utility/cookie-banner`
+
+Displays a fixed banner to inform users about cookie usage and collect consent.
+
+## ✅ Features
+
+-   Sticky banner anchored to page bottom
+-   Optional link to cookie policy
+-   Accept button stores consent and hides banner
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/utility/cookie-banner/cookie-banner.html",
+        "text": "We use cookies to improve your experience.",
+        "button": "Accept",
+        "link": {
+                "url": "/privacy",
+                "label": "Learn more"
+        }
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div id="cookieBanner" class="cookie-banner">
+        <div class="cookie-banner__content">
+                <span class="cookie-banner__text">{{{section.text}}}</span>
+                {% if section.link %}
+                <a href="{{{section.link.url}}}" class="cookie-banner__link">{{{section.link.label}}}</a>
+                {% endif %}
+        </div>
+        <button class="cookie-banner__button" onclick="acceptCookies()">
+                {{{section.button}}}
+        </button>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses CSS variables for colors, typography, spacing, and responsiveness
+-   Banner hides by adding the `.hidden` class after consent
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| --- | --- |
+| `--c-secondary` | Banner background |
+| `--c-primary`, `--c-primary-hover` | Button colors |
+| `--c-text-primary` | Text color |
+| `--font-size`, `--line-height`, `--letter-spacing` | Typography |
+| `--padding-scale`, `--margin-scale` | Spacing |
+| `--b-radius` | Button radius |
+| `--transition` | Hover transitions |
+| `--bp-md` | Responsive breakpoint |


### PR DESCRIPTION
## Summary
- add cookie banner utility section with styling and docs
- wire cookie banner styles into global stylesheet
- hide banner after acceptance via client-side cookie check

## Testing
- `node --check template/js/index.js`
- `npx -y sass template/sections/utility/cookie-banner/_cookie-banner.scss /tmp/cookie-banner.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896fd4fdfd48333a4f1460b919d7e77