### PR TITLE
feat: add utility alert section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,45 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.alert {
+  position: relative;
+  padding: calc(16px * var(--padding-scale)) calc(20px * var(--padding-scale));
+  margin: calc(16px * var(--margin-scale)) 0;
+  border: 1px solid var(--c-border);
+  border-radius: var(--b-radius);
+  background-color: var(--c-bg-item);
+  color: var(--c-text-primary);
+  font-family: var(--ff-base);
+  line-height: var(--line-height);
+}
+.alert__title {
+  font-family: var(--ff-title);
+  font-weight: 600;
+  margin-bottom: calc(8px * var(--margin-scale));
+}
+.alert__close {
+  position: absolute;
+  top: calc(8px * var(--padding-scale));
+  right: calc(8px * var(--padding-scale));
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: calc(var(--font-size) * 1.25);
+  cursor: pointer;
+}
+.alert--success {
+  border-color: var(--c-success-border);
+  background-color: var(--c-success);
+}
+.alert--danger {
+  border-color: var(--c-danger-border);
+  background-color: var(--c-error);
+}
+.alert--warning {
+  border-color: var(--c-warning-border);
+  background-color: var(--c-alert);
+}
+.alert--info {
+  border-color: var(--c-info-border);
+  background-color: var(--c-blue);
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/utility/alert/alert";

--- a/template/sections/utility/alert/LICENSE
+++ b/template/sections/utility/alert/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/utility/alert/_alert.scss
+++ b/template/sections/utility/alert/_alert.scss
@@ -1,0 +1,50 @@
+// alert section
+
+.alert {
+        position: relative;
+        padding: calc(16px * var(--padding-scale)) calc(20px * var(--padding-scale));
+        margin: calc(16px * var(--margin-scale)) 0;
+        border: 1px solid var(--c-border);
+        border-radius: var(--b-radius);
+        background-color: var(--c-bg-item);
+        color: var(--c-text-primary);
+        font-family: var(--ff-base);
+        line-height: var(--line-height);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-weight: 600;
+                margin-bottom: calc(8px * var(--margin-scale));
+        }
+
+        &__close {
+                position: absolute;
+                top: calc(8px * var(--padding-scale));
+                right: calc(8px * var(--padding-scale));
+                background: none;
+                border: none;
+                color: inherit;
+                font-size: calc(var(--font-size) * 1.25);
+                cursor: pointer;
+        }
+
+        &--success {
+                border-color: var(--c-success-border);
+                background-color: var(--c-success);
+        }
+
+        &--danger {
+                border-color: var(--c-danger-border);
+                background-color: var(--c-error);
+        }
+
+        &--warning {
+                border-color: var(--c-warning-border);
+                background-color: var(--c-alert);
+        }
+
+        &--info {
+                border-color: var(--c-info-border);
+                background-color: var(--c-blue);
+        }
+}

--- a/template/sections/utility/alert/alert.html
+++ b/template/sections/utility/alert/alert.html
@@ -1,0 +1,13 @@
+<div class="alert alert--{{section.type}}">
+        {% if section.close %}
+        <button class="alert__close" type="button">&times;</button>
+        {% endif %}
+
+        {% if section.title %}
+        <div class="alert__title">{{{section.title}}}</div>
+        {% endif %}
+
+        {% if section.message %}
+        <div class="alert__message">{{{section.message}}}</div>
+        {% endif %}
+</div>

--- a/template/sections/utility/alert/module.json
+++ b/template/sections/utility/alert/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-utility-alert.git" }

--- a/template/sections/utility/alert/readme.MD
+++ b/template/sections/utility/alert/readme.MD
@@ -1,0 +1,72 @@
+# 📂 Alert `/sections/utility/alert`
+
+Reusable alert/notification component with optional title, message and dismiss button.
+
+## ✅ Features
+
+-   Supports variants: `success`, `danger`, `warning`, `info`
+-   Optional close button
+-   Title and message are conditionally rendered
+-   Theming via CSS variables and global design tokens
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+        "src": "/sections/utility/alert/alert.html",
+        "type": "success",
+        "title": "Alert title",
+        "message": "Alert message goes here",
+        "close": true
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="alert alert--{{section.type}}">
+        {% if section.close %}
+        <button class="alert__close" type="button">&times;</button>
+        {% endif %}
+
+        {% if section.title %}
+        <div class="alert__title">{{{section.title}}}</div>
+        {% endif %}
+
+        {% if section.message %}
+        <div class="alert__message">{{{section.message}}}</div>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Spacing scales with `--padding-scale` and `--margin-scale`
+-   Variant colors use theme tokens (`--c-success`, `--c-error`, `--c-alert`, `--c-blue`)
+-   Borders follow variant border tokens (`--c-success-border`, etc.)
+-   Typography controlled via `--ff-base`, `--ff-title`, and `--font-size`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| --- | --- |
+| `--padding-scale` | Controls padding |
+| `--margin-scale` | Controls margin spacing |
+| `--b-radius` | Rounds alert container |
+| `--c-border` | Default border color |
+| `--c-bg-item` | Default background |
+| `--c-text-primary` | Text color |
+| `--c-success`, `--c-error`, `--c-alert`, `--c-blue` | Variant backgrounds |
+| `--c-success-border`, `--c-danger-border`, `--c-warning-border`, `--c-info-border` | Variant borders |
+| `--font-size` | Base font size |
+| `--ff-base` | Font for message |
+| `--ff-title` | Font for title |
+| `--line-height` | Line height for text |
+
+---


### PR DESCRIPTION
## Summary
- add configurable alert utility section with variants and close button
- document alert component and include module metadata
- wire alert styles into global index

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fd46c5e4833394cf2e1a11d2f21c