### PR TITLE
feat: add structured data seo section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/seo/structured-data/structured-data";

--- a/template/sections/seo/structured-data/LICENSE
+++ b/template/sections/seo/structured-data/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/seo/structured-data/_structured-data.scss
+++ b/template/sections/seo/structured-data/_structured-data.scss
@@ -1,0 +1,2 @@
+// structured-data section
+// No visual styling needed; placeholder for consistency

--- a/template/sections/seo/structured-data/module.json
+++ b/template/sections/seo/structured-data/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-seo-structured-data.git" }

--- a/template/sections/seo/structured-data/readme.MD
+++ b/template/sections/seo/structured-data/readme.MD
@@ -1,0 +1,44 @@
+# 📂 Structured Data `/sections/seo/structured-data`
+
+Outputs a JSON-LD script block for injecting custom structured data.
+
+## ✅ Features
+
+-   Accepts raw JSON-LD input
+-   Conditionally renders the script when data is provided
+-   Non-visual section; no layout or styling required
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/seo/structured-data/structured-data.html",
+        "data": "{ \"@context\": \"https://schema.org\", \"@type\": \"WebSite\" }"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+{% if section.data %}
+<script type="application/ld+json">
+{{{section.data}}}
+</script>
+{% endif %}
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   This section has no visual output. The accompanying `_structured-data.scss` file is intentionally minimal for consistency.
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+-   None

--- a/template/sections/seo/structured-data/structured-data.html
+++ b/template/sections/seo/structured-data/structured-data.html
@@ -1,0 +1,5 @@
+{% if section.data %}
+<script type="application/ld+json">
+{{{section.data}}}
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add SEO structured data section with JSON-LD output
- document structured data section and include placeholder styles
- wire new section styles into global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fd144bd08333bc767b375df851ff