### PR TITLE
feat: add seo og preview section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/seo/og-preview/og-preview";

--- a/template/sections/seo/og-preview/LICENSE
+++ b/template/sections/seo/og-preview/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/seo/og-preview/_og-preview.scss
+++ b/template/sections/seo/og-preview/_og-preview.scss
@@ -1,0 +1,62 @@
+// og-preview section
+
+.og-preview {
+        display: flex;
+        max-width: 500px;
+        margin: 0 auto;
+        font-family: var(--ff-base);
+        background-color: var(--c-bg-item);
+        border: 1px solid var(--c-border);
+        border-radius: var(--b-radius);
+        overflow: hidden;
+
+        &__image {
+                width: 40%;
+                img {
+                        display: block;
+                        width: 100%;
+                        height: 100%;
+                        object-fit: cover;
+                }
+        }
+
+        &__content {
+                padding: calc(12px * var(--padding-scale));
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                flex: 1;
+                text-align: left;
+        }
+
+        &__url {
+                font-size: calc(var(--font-size) * 0.75);
+                color: var(--c-text-body-secondary);
+                margin-bottom: calc(4px * var(--margin-scale));
+        }
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: calc(var(--font-size) * 1.1);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                margin-top: calc(8px * var(--margin-scale));
+                font-size: calc(var(--font-size) * 0.9);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-secondary);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .og-preview {
+                flex-direction: column;
+        }
+        .og-preview__image {
+                width: 100%;
+        }
+}

--- a/template/sections/seo/og-preview/module.json
+++ b/template/sections/seo/og-preview/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-seo-og-preview.git" }

--- a/template/sections/seo/og-preview/og-preview.html
+++ b/template/sections/seo/og-preview/og-preview.html
@@ -1,0 +1,18 @@
+<div class="og-preview">
+        {% if section.image %}
+        <div class="og-preview__image">
+                <img src="{{{section.image}}}" alt="" />
+        </div>
+        {% endif %}
+        <div class="og-preview__content">
+                {% if section.url %}
+                <div class="og-preview__url">{{{section.url}}}</div>
+                {% endif %}
+                {% if section.title %}
+                <div class="og-preview__title">{{{section.title}}}</div>
+                {% endif %}
+                {% if section.description %}
+                <div class="og-preview__description">{{{section.description}}}</div>
+                {% endif %}
+        </div>
+</div>

--- a/template/sections/seo/og-preview/readme.MD
+++ b/template/sections/seo/og-preview/readme.MD
@@ -1,0 +1,72 @@
+# 📂 OG Preview `/sections/seo/og-preview`
+
+Open Graph preview card section for displaying link metadata (image, title, description, and URL). Useful for showing how links will appear when shared on social platforms.
+
+## ✅ Features
+
+-   Optional URL, title, description, and image
+-   Responsive layout that stacks on smaller screens
+-   Uses global CSS variables for typography, colors, spacing, and breakpoints
+-   Themed through `template.json` variables
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/seo/og-preview/og-preview.html",
+        "image": "/img/preview.png",
+        "url": "example.com/article",
+        "title": "Link preview title",
+        "description": "Short summary used for social preview"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="og-preview">
+        {% if section.image %}
+        <div class="og-preview__image">
+                <img src="{{{section.image}}}" alt="" />
+        </div>
+        {% endif %}
+        <div class="og-preview__content">
+                {% if section.url %}
+                <div class="og-preview__url">{{{section.url}}}</div>
+                {% endif %}
+                {% if section.title %}
+                <div class="og-preview__title">{{{section.title}}}</div>
+                {% endif %}
+                {% if section.description %}
+                <div class="og-preview__description">{{{section.description}}}</div>
+                {% endif %}
+        </div>
+</div>
+```
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                        |
+| ------------------------------- | -------------------------------------------------- |
+| `--ff-base`                     | Base font for description                          |
+| `--ff-title`                    | Font for the title                                 |
+| `--padding-scale`               | Controls padding in the content area               |
+| `--margin-scale`                | Controls spacing for description and URL           |
+| `--font-size`                   | Base font size for text                            |
+| `--line-height`                 | Line height for text                               |
+| `--letter-spacing`              | Letter spacing for text                            |
+| `--c-bg-item`                   | Card background color                              |
+| `--c-border`                    | Border color                                       |
+| `--c-text-primary`              | Title text color                                   |
+| `--c-text-secondary`            | Description text color                             |
+| `--c-text-body-secondary`       | URL text color                                     |
+| `--b-radius`                    | Card border radius                                 |
+| `--bp-md`                       | Breakpoint for stacking layout                     |
+
+---


### PR DESCRIPTION
## Summary
- add Open Graph preview section with HTML template and SCSS styling
- document new section and link to repository
- register og-preview styles in global index

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6896fcfac67c8333ab9a0dc4d491ff6a