### PR TITLE
feat: add meta preview section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,70 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.meta-preview {
+        display: flex;
+        align-items: flex-start;
+        gap: calc(12px * var(--margin-scale));
+        font-family: var(--ff-base);
+        max-width: 600px;
+        margin-left: auto;
+        margin-right: auto;
+}
+.meta-preview__image {
+        width: 120px;
+        flex-shrink: 0;
+        margin-bottom: calc(8px * var(--margin-scale));
+}
+.meta-preview__image img {
+        width: 100%;
+        display: block;
+        border-radius: var(--b-radius);
+}
+.meta-preview__body {
+        flex: 1;
+}
+.meta-preview__title {
+        font-family: var(--ff-title);
+        font-size: 18px;
+        line-height: var(--line-height);
+        color: var(--c-blue);
+}
+.meta-preview__url {
+        font-size: 14px;
+        line-height: var(--line-height);
+        color: var(--c-green);
+        margin-top: calc(4px * var(--margin-scale));
+        word-break: break-all;
+}
+.meta-preview__description {
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        color: var(--c-text-body-secondary);
+        margin-top: calc(8px * var(--margin-scale));
+}
+@media screen and (max-width: var(--bp-lg)) {
+        .meta-preview__title {
+                font-size: 16px;
+        }
+}
+@media screen and (max-width: var(--bp-md)) {
+        .meta-preview__title {
+                font-size: 14px;
+        }
+        .meta-preview__image {
+                width: 90px;
+        }
+}
+@media screen and (max-width: var(--bp-sm)) {
+        .meta-preview {
+                flex-direction: column;
+        }
+        .meta-preview__image {
+                width: 100%;
+                max-width: 200px;
+                margin-bottom: calc(12px * var(--margin-scale));
+        }
+        .meta-preview__url {
+                font-size: 12px;
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/seo/meta-preview/meta-preview";

--- a/template/sections/seo/meta-preview/LICENSE
+++ b/template/sections/seo/meta-preview/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/seo/meta-preview/_meta-preview.scss
+++ b/template/sections/seo/meta-preview/_meta-preview.scss
@@ -1,0 +1,79 @@
+// meta preview section
+
+.meta-preview {
+        display: flex;
+        align-items: flex-start;
+        gap: calc(12px * var(--margin-scale));
+        font-family: var(--ff-base);
+        max-width: 600px;
+        margin-left: auto;
+        margin-right: auto;
+
+        &__image {
+                width: 120px;
+                flex-shrink: 0;
+                margin-bottom: calc(8px * var(--margin-scale));
+
+                img {
+                        width: 100%;
+                        display: block;
+                        border-radius: var(--b-radius);
+                }
+        }
+
+        &__body {
+                flex: 1;
+        }
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 18px;
+                line-height: var(--line-height);
+                color: var(--c-blue);
+        }
+
+        &__url {
+                font-size: 14px;
+                line-height: var(--line-height);
+                color: var(--c-green);
+                margin-top: calc(4px * var(--margin-scale));
+                word-break: break-all;
+        }
+
+        &__description {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                color: var(--c-text-body-secondary);
+                margin-top: calc(8px * var(--margin-scale));
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .meta-preview__title {
+                font-size: 16px;
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .meta-preview__title {
+                font-size: 14px;
+        }
+        .meta-preview__image {
+                width: 90px;
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .meta-preview {
+                flex-direction: column;
+        }
+        .meta-preview__image {
+                width: 100%;
+                max-width: 200px;
+                margin-bottom: calc(12px * var(--margin-scale));
+        }
+        .meta-preview__url {
+                font-size: 12px;
+        }
+}
+

--- a/template/sections/seo/meta-preview/meta-preview.html
+++ b/template/sections/seo/meta-preview/meta-preview.html
@@ -1,0 +1,19 @@
+<div class="meta-preview">
+        {% if section.image %}
+        <div class="meta-preview__image">
+                <img src="{{{section.image}}}" alt="" />
+        </div>
+        {% endif %}
+        <div class="meta-preview__body">
+                {% if section.title %}
+                <div class="meta-preview__title">{{{section.title}}}</div>
+                {% endif %}
+                {% if section.url %}
+                <div class="meta-preview__url">{{{section.url}}}</div>
+                {% endif %}
+                {% if section.description %}
+                <div class="meta-preview__description">{{{section.description}}}</div>
+                {% endif %}
+        </div>
+</div>
+

--- a/template/sections/seo/meta-preview/module.json
+++ b/template/sections/seo/meta-preview/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-seo-meta-preview.git" }

--- a/template/sections/seo/meta-preview/readme.MD
+++ b/template/sections/seo/meta-preview/readme.MD
@@ -1,0 +1,75 @@
+# 🔍 Meta Preview `/sections/seo/meta-preview`
+
+Meta preview section that emulates how a page might appear in search results or link previews. Displays title, URL, description, and optional image.
+
+## ✅ Features
+
+-   Optional image, title, url, and description
+-   Responsive layout with configurable theme variables
+-   Uses flexbox for layout and adapts across breakpoints
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via section
+
+```json
+{
+        "src": "/sections/seo/meta-preview/meta-preview.html",
+        "image": "/img/og-image.jpg",
+        "title": "Page title used for preview",
+        "url": "https://example.com/page",
+        "description": "Optional meta description for preview"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="meta-preview">
+        {% if section.image %}
+        <div class="meta-preview__image">
+                <img src="{{{section.image}}}" alt="" />
+        </div>
+        {% endif %}
+        <div class="meta-preview__body">
+                {% if section.title %}
+                <div class="meta-preview__title">{{{section.title}}}</div>
+                {% endif %}
+                {% if section.url %}
+                <div class="meta-preview__url">{{{section.url}}}</div>
+                {% endif %}
+                {% if section.description %}
+                <div class="meta-preview__description">{{{section.description}}}</div>
+                {% endif %}
+        </div>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Flex layout with optional image block
+-   Font sizes adjust via breakpoints
+-   URL and description use theme colors for consistency
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                        |
+| ------------------------------- | -------------------------------------------------- |
+| `--margin-scale`                | Controls spacing between elements                  |
+| `--font-size`                   | Base font size for description                     |
+| `--line-height`                 | Line height for text                               |
+| `--b-radius`                    | Rounds preview image                               |
+| `--ff-base`                     | Font for URL and description                       |
+| `--ff-title`                    | Font for preview title                             |
+| `--c-blue`                      | Title color                                        |
+| `--c-green`                     | URL color                                          |
+| `--c-text-body-secondary`       | Description text color                             |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Used in media queries for responsiveness           |
+
+---


### PR DESCRIPTION
## Summary
- add SEO meta preview section with optional image, title, url and description
- wire new section styles into global stylesheet

## Testing
- `npx --yes sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896fcf03178833384fb9be7ed43c111