### PR TITLE
feat: add FAQ schema SEO section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/seo/faq-schema/faq-schema";

--- a/template/sections/seo/faq-schema/LICENSE
+++ b/template/sections/seo/faq-schema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/seo/faq-schema/_faq-schema.scss
+++ b/template/sections/seo/faq-schema/_faq-schema.scss
@@ -1,0 +1,4 @@
+// faq-schema section
+
+// This section only outputs JSON-LD structured data for FAQs and
+// does not render visible elements.

--- a/template/sections/seo/faq-schema/faq-schema.html
+++ b/template/sections/seo/faq-schema/faq-schema.html
@@ -1,0 +1,20 @@
+{% if section.items %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {% for item in section.items %}
+    {
+      "@type": "Question",
+      "name": "{{{item.question}}}",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "{{{item.answer}}}"
+      }
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
+}
+</script>
+{% endif %}

--- a/template/sections/seo/faq-schema/module.json
+++ b/template/sections/seo/faq-schema/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-seo-faq-schema.git" }

--- a/template/sections/seo/faq-schema/readme.MD
+++ b/template/sections/seo/faq-schema/readme.MD
@@ -1,0 +1,72 @@
+# 📂 FAQ Schema `/sections/seo/faq-schema`
+
+Embeds JSON-LD structured data for Frequently Asked Questions.
+Improves SEO by helping search engines understand Q&A content.
+
+## ✅ Features
+
+-   Generates valid `FAQPage` schema
+-   Data-driven: questions and answers from `section.items`
+-   No visual output – purely for search engine indexing
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following structure passed via `section`:
+
+```json
+{
+  "src": "/sections/seo/faq-schema/faq-schema.html",
+  "items": [
+    {
+      "question": "What is your return policy?",
+      "answer": "You can return any item within 30 days of purchase."
+    },
+    {
+      "question": "Do you ship internationally?",
+      "answer": "Yes, we ship to most countries worldwide."
+    }
+  ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+{% if section.items %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {% for item in section.items %}
+    {
+      "@type": "Question",
+      "name": "{{{item.question}}}",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "{{{item.answer}}}"
+      }
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
+}
+</script>
+{% endif %}
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   This section outputs only a `<script>` tag and has no visible UI.
+-   `_faq-schema.scss` is included for consistency but contains no styles.
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+This section does not consume any theme variables.
+
+---


### PR DESCRIPTION
## Summary
- add SEO FAQ schema section with JSON-LD generation
- document expected data structure for FAQ schema section
- register section styles in main index.scss

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fce3f8648333aa4c9ca77557786d