### PR TITLE
feat: add breadcrumb schema section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/seo/breadcrumb-schema/breadcrumb-schema";

--- a/template/sections/seo/breadcrumb-schema/LICENSE
+++ b/template/sections/seo/breadcrumb-schema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/seo/breadcrumb-schema/_breadcrumb-schema.scss
+++ b/template/sections/seo/breadcrumb-schema/_breadcrumb-schema.scss
@@ -1,0 +1,5 @@
+// breadcrumb schema section
+
+.breadcrumb-schema {
+        display: none;
+}

--- a/template/sections/seo/breadcrumb-schema/breadcrumb-schema.html
+++ b/template/sections/seo/breadcrumb-schema/breadcrumb-schema.html
@@ -1,0 +1,18 @@
+{% if section.items %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {% for crumb in section.items %}
+    {
+      "@type": "ListItem",
+      "position": {{ loop.index }},
+      "name": "{{{crumb.name}}}",{% if crumb.url %}
+      "item": "{{{crumb.url}}}"{% endif %}
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
+}
+</script>
+{% endif %}

--- a/template/sections/seo/breadcrumb-schema/module.json
+++ b/template/sections/seo/breadcrumb-schema/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-seo-breadcrumb-schema.git" }

--- a/template/sections/seo/breadcrumb-schema/readme.MD
+++ b/template/sections/seo/breadcrumb-schema/readme.MD
@@ -1,0 +1,55 @@
+# 📂 Breadcrumb Schema `/sections/seo/breadcrumb-schema`
+
+Outputs [JSON-LD BreadcrumbList](https://schema.org/BreadcrumbList) markup based on the provided items for improved SEO.
+
+## ✅ Features
+
+- Generates structured data for breadcrumbs.
+- Each item includes its position automatically.
+- Hidden from view to avoid affecting layout.
+
+---
+
+## 🧾 Section Data Schema
+
+```json
+{
+  "src": "/sections/seo/breadcrumb-schema/breadcrumb-schema.html",
+  "items": [
+    { "name": "Home", "url": "/" },
+    { "name": "Blog", "url": "/blog" },
+    { "name": "Post" }
+  ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+{% if section.items %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {% for crumb in section.items %}
+    {
+      "@type": "ListItem",
+      "position": {{ loop.index }},
+      "name": "{{{crumb.name}}}",{% if crumb.url %}
+      "item": "{{{crumb.url}}}"{% endif %}
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
+}
+</script>
+{% endif %}
+```
+
+---
+
+## 🎨 Styling Notes
+
+- `.breadcrumb-schema` is hidden using `display: none;`.
+- Leverages global CSS variables if extended in the future.
+


### PR DESCRIPTION
## Summary
- add SEO breadcrumb schema section with JSON-LD output
- include breadcrumb schema styles and docs

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `sass template/css/index.scss template/css/index.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896fcdb6a64833398e6ba49ee7d8803