### PR TITLE
feat: add article schema section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,9 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+
+.article-schema {
+	display: none;
+	font-size: var(--font-size);
+	color: var(--c-text-primary);
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/seo/article-schema/article-schema";

--- a/template/sections/seo/article-schema/LICENSE
+++ b/template/sections/seo/article-schema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/seo/article-schema/_article-schema.scss
+++ b/template/sections/seo/article-schema/_article-schema.scss
@@ -1,0 +1,7 @@
+// article schema section
+
+.article-schema {
+        display: none;
+        font-size: var(--font-size);
+        color: var(--c-text-primary);
+}

--- a/template/sections/seo/article-schema/article-schema.html
+++ b/template/sections/seo/article-schema/article-schema.html
@@ -1,0 +1,28 @@
+<div class="article-schema">
+        <script type="application/ld+json">
+                {
+                        "@context": "https://schema.org",
+                        "@type": "Article",
+                        "headline": "{{{section.headline}}}",
+                        "image": "{{{section.image}}}",
+                        "datePublished": "{{{section.datePublished}}}",
+                        "dateModified": "{{{section.dateModified}}}",
+                        "author": {
+                                "@type": "Person",
+                                "name": "{{{section.author}}}"
+                        },
+                        "publisher": {
+                                "@type": "Organization",
+                                "name": "{{{section.publisherName}}}",
+                                "logo": {
+                                        "@type": "ImageObject",
+                                        "url": "{{{section.publisherLogo}}}"
+                                }
+                        },
+                        "mainEntityOfPage": {
+                                "@type": "WebPage",
+                                "@id": "{{{section.url}}}"
+                        }
+                }
+        </script>
+</div>

--- a/template/sections/seo/article-schema/module.json
+++ b/template/sections/seo/article-schema/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-seo-article-schema.git" }

--- a/template/sections/seo/article-schema/readme.MD
+++ b/template/sections/seo/article-schema/readme.MD
@@ -1,0 +1,79 @@
+# 📰 Article Schema `/sections/seo/article-schema`
+
+Outputs [JSON-LD](https://json-ld.org/) markup for articles to improve SEO and social sharing.
+
+## ✅ Features
+
+-   Generates valid `Article` structured data
+-   All fields mapped from section data
+-   Hidden container styled with theme variables
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/seo/article-schema/article-schema.html",
+        "headline": "Article title",
+        "image": "https://example.com/cover.jpg",
+        "datePublished": "2024-01-01",
+        "dateModified": "2024-01-02",
+        "author": "Jane Doe",
+        "publisherName": "Example Inc",
+        "publisherLogo": "https://example.com/logo.png",
+        "url": "https://example.com/article"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="article-schema">
+        <script type="application/ld+json">
+                {
+                        "@context": "https://schema.org",
+                        "@type": "Article",
+                        "headline": "{{{section.headline}}}",
+                        "image": "{{{section.image}}}",
+                        "datePublished": "{{{section.datePublished}}}",
+                        "dateModified": "{{{section.dateModified}}}",
+                        "author": {
+                                "@type": "Person",
+                                "name": "{{{section.author}}}"
+                        },
+                        "publisher": {
+                                "@type": "Organization",
+                                "name": "{{{section.publisherName}}}",
+                                "logo": {
+                                        "@type": "ImageObject",
+                                        "url": "{{{section.publisherLogo}}}"
+                                }
+                        },
+                        "mainEntityOfPage": {
+                                "@type": "WebPage",
+                                "@id": "{{{section.url}}}"
+                        }
+                }
+        </script>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   `.article-schema` container is hidden by default
+-   Uses `--font-size` and `--c-text-primary` for theming consistency
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable            | Description            |
+| ------------------- | ---------------------- |
+| `--font-size`       | Base font size         |
+| `--c-text-primary`  | Primary text color     |
+


### PR DESCRIPTION
## Summary
- add Article Schema SEO section with JSON-LD output and styling hook
- document usage and theme variables
- wire new section into global styles

## Testing
- `npx --yes sass --no-source-map template/css/index.scss template/css/index.css` *(fails: 403 Forbidden to fetch sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc9901808333aa122ef95d95b317