### PR TITLE
feat: add table-of-contents navigation section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,42 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.table-of-contents {
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+}
+.table-of-contents__title {
+        font-family: var(--ff-title);
+        font-size: 24px;
+        font-weight: 600;
+        color: var(--c-text-primary);
+        margin-bottom: calc(12px * var(--margin-scale));
+}
+.table-of-contents__list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+}
+.table-of-contents__item {
+        margin-bottom: calc(8px * var(--margin-scale));
+}
+.table-of-contents__link {
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-primary);
+        text-decoration: none;
+        transition: color var(--transition);
+}
+.table-of-contents__link:hover {
+        color: var(--c-primary-hover);
+}
+.table-of-contents__sublist {
+        list-style: none;
+        padding-left: calc(16px * var(--padding-scale));
+        margin-top: calc(4px * var(--margin-scale));
+}
+.table-of-contents__subitem {
+        margin-bottom: calc(4px * var(--margin-scale));
+}
+

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/navigation/table-of-contents/table-of-contents";

--- a/template/sections/navigation/table-of-contents/LICENSE
+++ b/template/sections/navigation/table-of-contents/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/navigation/table-of-contents/_table-of-contents.scss
+++ b/template/sections/navigation/table-of-contents/_table-of-contents.scss
@@ -1,0 +1,47 @@
+// table-of-contents section
+
+.table-of-contents {
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 24px;
+                font-weight: 600;
+                color: var(--c-text-primary);
+                margin-bottom: calc(12px * var(--margin-scale));
+        }
+
+        &__list {
+                list-style: none;
+                padding: 0;
+                margin: 0;
+        }
+
+        &__item {
+                margin-bottom: calc(8px * var(--margin-scale));
+        }
+
+        &__link {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-primary);
+                text-decoration: none;
+                transition: color var(--transition);
+        }
+
+        &__link:hover {
+                color: var(--c-primary-hover);
+        }
+
+        &__sublist {
+                list-style: none;
+                padding-left: calc(16px * var(--padding-scale));
+                margin-top: calc(4px * var(--margin-scale));
+        }
+
+        &__subitem {
+                margin-bottom: calc(4px * var(--margin-scale));
+        }
+}

--- a/template/sections/navigation/table-of-contents/module.json
+++ b/template/sections/navigation/table-of-contents/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-navigation-table-of-contents.git" }

--- a/template/sections/navigation/table-of-contents/readme.MD
+++ b/template/sections/navigation/table-of-contents/readme.MD
@@ -1,0 +1,79 @@
+# 📂 Table of Contents `/sections/navigation/table-of-contents`
+
+Navigation block that lists page headings and links to them via anchors. Supports optional title and nested items.
+
+## ✅ Features
+
+-   Optional section title
+-   Generates list of anchor links from provided items
+-   Supports nested child items
+-   Uses CSS variables for fonts, colors, spacing and transitions
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`
+
+```json
+{
+        "src": "/sections/navigation/table-of-contents/table-of-contents.html",
+        "title": "On this page",
+        "items": [
+                { "id": "intro", "text": "Introduction" },
+                {
+                        "id": "setup",
+                        "text": "Setup",
+                        "children": [
+                                { "id": "install", "text": "Install" }
+                        ]
+                }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="table-of-contents">
+        {% if section.title %}
+        <div class="table-of-contents__title">{{{section.title}}}</div>
+        {% endif %} {% if section.items %}
+        <ul class="table-of-contents__list">
+                {% for item in section.items %}
+                <li class="table-of-contents__item">
+                        <a href="#{{{item.id}}}" class="table-of-contents__link">{{{item.text}}}</a>
+                        {% if item.children %}
+                        <ul class="table-of-contents__sublist">
+                                {% for child in item.children %}
+                                <li class="table-of-contents__subitem">
+                                        <a href="#{{{child.id}}}" class="table-of-contents__link">{{{child.text}}}</a>
+                                </li>
+                                {% endfor %}
+                        </ul>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable              | Description                          |
+| --------------------- | ------------------------------------ |
+| `--padding-scale`     | Scales padding for section spacing   |
+| `--margin-scale`      | Controls spacing between list items  |
+| `--font-size`         | Base font size for links             |
+| `--line-height`       | Line height for links                |
+| `--letter-spacing`    | Letter spacing for link text         |
+| `--ff-base`           | Font family for links                |
+| `--ff-title`          | Font family for section title        |
+| `--c-primary`         | Link color                           |
+| `--c-primary-hover`   | Link hover color                     |
+| `--c-text-primary`    | Title text color                     |
+| `--transition`        | Transition for link hover effect     |
+

--- a/template/sections/navigation/table-of-contents/table-of-contents.html
+++ b/template/sections/navigation/table-of-contents/table-of-contents.html
@@ -1,0 +1,22 @@
+<div class="table-of-contents">
+        {% if section.title %}
+        <div class="table-of-contents__title">{{{section.title}}}</div>
+        {% endif %} {% if section.items %}
+        <ul class="table-of-contents__list">
+                {% for item in section.items %}
+                <li class="table-of-contents__item">
+                        <a href="#{{{item.id}}}" class="table-of-contents__link">{{{item.text}}}</a>
+                        {% if item.children %}
+                        <ul class="table-of-contents__sublist">
+                                {% for child in item.children %}
+                                <li class="table-of-contents__subitem">
+                                        <a href="#{{{child.id}}}" class="table-of-contents__link">{{{child.text}}}</a>
+                                </li>
+                                {% endfor %}
+                        </ul>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add navigation table-of-contents section with optional nested items
- style table-of-contents with theme variables
- register section styles in global stylesheet

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc871cf88333846a4b8691814115