### PR TITLE
feat: add pagination navigation section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/navigation/pagination/pagination";

--- a/template/sections/navigation/pagination/LICENSE
+++ b/template/sections/navigation/pagination/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/navigation/pagination/_pagination.scss
+++ b/template/sections/navigation/pagination/_pagination.scss
@@ -1,0 +1,56 @@
+// pagination navigation section
+
+.pagination {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: calc(12px * var(--margin-scale));
+        padding: calc(20px * var(--padding-scale)) 0;
+        font-family: var(--ff-base);
+
+        &__list {
+                display: flex;
+                list-style: none;
+                gap: calc(8px * var(--margin-scale));
+                margin: 0;
+                padding: 0;
+        }
+
+        &__item {
+                display: flex;
+        }
+
+        &__prev,
+        &__next,
+        &__link {
+                display: inline-block;
+                text-decoration: none;
+                color: var(--c-text-primary);
+                padding: calc(8px * var(--padding-scale)) calc(12px * var(--padding-scale));
+                border: 1px solid var(--c-border);
+                border-radius: var(--b-radius);
+                transition: background-color var(--transition), color var(--transition), border-color var(--transition);
+        }
+
+        &__prev:hover,
+        &__next:hover,
+        &__link:hover {
+                background-color: var(--c-primary-hover);
+                color: var(--c-text-secondary);
+                border-color: var(--c-primary);
+        }
+
+        &__link.is-current {
+                background-color: var(--c-primary);
+                color: var(--c-text-secondary);
+                border-color: var(--c-primary);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .pagination {
+                flex-wrap: wrap;
+                gap: calc(8px * var(--margin-scale));
+        }
+}
+

--- a/template/sections/navigation/pagination/module.json
+++ b/template/sections/navigation/pagination/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-navigation-pagination.git" }

--- a/template/sections/navigation/pagination/pagination.html
+++ b/template/sections/navigation/pagination/pagination.html
@@ -1,0 +1,21 @@
+<nav class="pagination">
+        {% if section.prev %}
+        <a class="pagination__prev" href="{{{section.prev}}}">{{{section.prevLabel || 'Prev'}}}</a>
+        {% endif %}
+        {% if section.pages %}
+        <ul class="pagination__list">
+                {% for page in section.pages %}
+                <li class="pagination__item">
+                        {% if page.url %}
+                        <a href="{{{page.url}}}" class="pagination__link{% if page.current %} is-current{% endif %}">{{{page.label}}}</a>
+                        {% else %}
+                        <span class="pagination__link{% if page.current %} is-current{% endif %}">{{{page.label}}}</span>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+        {% if section.next %}
+        <a class="pagination__next" href="{{{section.next}}}">{{{section.nextLabel || 'Next'}}}</a>
+        {% endif %}
+</nav>

--- a/template/sections/navigation/pagination/readme.MD
+++ b/template/sections/navigation/pagination/readme.MD
@@ -1,0 +1,88 @@
+# 📂 Pagination `/sections/navigation/pagination`
+
+Navigation component for switching between paged content.
+
+## ✅ Features
+
+-   Optional previous and next links
+-   Highlighted current page
+-   Dynamic page list rendered from data array
+-   Responsive flex layout
+-   Styling driven by CSS variables for easy theming
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via section
+
+```json
+{
+        "src": "/sections/navigation/pagination/pagination.html",
+        "prev": "/page/1",
+        "next": "/page/3",
+        "prevLabel": "Prev",
+        "nextLabel": "Next",
+        "pages": [
+                { "url": "/page/1", "label": "1" },
+                { "url": "/page/2", "label": "2", "current": true },
+                { "url": "/page/3", "label": "3" }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<nav class="pagination">
+        {% if section.prev %}
+        <a class="pagination__prev" href="{{{section.prev}}}">{{{section.prevLabel || 'Prev'}}}</a>
+        {% endif %}
+        {% if section.pages %}
+        <ul class="pagination__list">
+                {% for page in section.pages %}
+                <li class="pagination__item">
+                        {% if page.url %}
+                        <a href="{{{page.url}}}" class="pagination__link{% if page.current %} is-current{% endif %}">{{{page.label}}}</a>
+                        {% else %}
+                        <span class="pagination__link{% if page.current %} is-current{% endif %}">{{{page.label}}}</span>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+        {% endif %}
+        {% if section.next %}
+        <a class="pagination__next" href="{{{section.next}}}">{{{section.nextLabel || 'Next'}}}</a>
+        {% endif %}
+</nav>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses flexbox for alignment and spacing
+-   Spacing scales with `--padding-scale` and `--margin-scale`
+-   Hover and active states transition with `--transition`
+-   Current page styled with `--c-primary`
+-   Wraps items on small screens at `--bp-sm`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable              | Description                             |
+| --------------------- | --------------------------------------- |
+| `--ff-base`           | Font family for pagination text         |
+| `--padding-scale`     | Internal padding of links               |
+| `--margin-scale`      | Spacing between items                   |
+| `--c-text-primary`    | Default text color                      |
+| `--c-text-secondary`  | Text color on hover/active              |
+| `--c-primary`         | Background of active page               |
+| `--c-primary-hover`   | Background on hover                     |
+| `--c-border`          | Link border color                       |
+| `--b-radius`          | Border radius for links                 |
+| `--transition`        | Transition timing                       |
+| `--bp-sm`             | Breakpoint for responsive wrapping      |
+
+---


### PR DESCRIPTION
## Summary
- add navigation pagination section with logic and styling
- document pagination usage and theme variables
- register pagination styles in main index stylesheet

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc69e1c88333959ddaed494fabf8