### PR TITLE
feat: add navigation mega menu section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,76 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.mega-menu {
+        font-family: var(--ff-base);
+        background-color: var(--c-body);
+}
+.mega-menu__list {
+        display: flex;
+        gap: calc(20px * var(--margin-scale));
+        list-style: none;
+        margin: 0;
+        padding: 0;
+}
+.mega-menu__item {
+        position: relative;
+}
+.mega-menu__toggle {
+        display: block;
+        padding: calc(10px * var(--padding-scale)) calc(15px * var(--padding-scale));
+        color: var(--c-text-primary);
+        text-decoration: none;
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+}
+.mega-menu__content {
+        display: none;
+        position: absolute;
+        left: 0;
+        top: 100%;
+        width: 100%;
+        background-color: var(--c-bg-item);
+        box-shadow: 0 4px 8px var(--c-shadow);
+        padding: calc(20px * var(--padding-scale));
+}
+.mega-menu__item--open .mega-menu__content {
+        display: flex;
+}
+.mega-menu__column {
+        flex: 1;
+        padding: 0 calc(15px * var(--padding-scale));
+}
+.mega-menu__column-title {
+        font-family: var(--ff-title);
+        font-weight: 600;
+        color: var(--c-text-primary);
+        margin-bottom: calc(10px * var(--margin-scale));
+}
+.mega-menu__links {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+}
+.mega-menu__link {
+        display: block;
+        padding: calc(4px * var(--padding-scale)) 0;
+        color: var(--c-text-body-secondary);
+        text-decoration: none;
+        font-size: var(--font-size);
+        transition: color var(--transition);
+}
+.mega-menu__link:hover {
+        color: var(--c-primary-hover);
+}
+@media screen and (max-width: var(--bp-md)) {
+        .mega-menu__list {
+                flex-direction: column;
+        }
+        .mega-menu__item--open .mega-menu__content {
+                position: static;
+        }
+        .mega-menu__content {
+                box-shadow: none;
+                padding: calc(10px * var(--padding-scale));
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/navigation/mega-menu/mega-menu";

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -210,3 +210,15 @@ document.addEventListener("DOMContentLoaded", () => {
 		});
 	});
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll(".mega-menu__toggle").forEach((toggle) => {
+                toggle.addEventListener("click", (e) => {
+                        e.preventDefault();
+                        const item = toggle.closest(".mega-menu__item");
+                        if (item) {
+                                item.classList.toggle("mega-menu__item--open");
+                        }
+                });
+        });
+});

--- a/template/sections/navigation/mega-menu/LICENSE
+++ b/template/sections/navigation/mega-menu/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/navigation/mega-menu/_mega-menu.scss
+++ b/template/sections/navigation/mega-menu/_mega-menu.scss
@@ -1,0 +1,90 @@
+// mega menu section
+
+.mega-menu {
+        font-family: var(--ff-base);
+        background-color: var(--c-body);
+
+        &__list {
+                display: flex;
+                gap: calc(20px * var(--margin-scale));
+                list-style: none;
+                margin: 0;
+                padding: 0;
+        }
+
+        &__item {
+                position: relative;
+        }
+
+        &__toggle {
+                display: block;
+                padding: calc(10px * var(--padding-scale))
+                        calc(15px * var(--padding-scale));
+                color: var(--c-text-primary);
+                text-decoration: none;
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+        }
+
+        &__content {
+                display: none;
+                position: absolute;
+                left: 0;
+                top: 100%;
+                width: 100%;
+                background-color: var(--c-bg-item);
+                box-shadow: 0 4px 8px var(--c-shadow);
+                padding: calc(20px * var(--padding-scale));
+        }
+
+        &__item--open &__content {
+                display: flex;
+        }
+
+        &__column {
+                flex: 1;
+                padding: 0 calc(15px * var(--padding-scale));
+        }
+
+        &__column-title {
+                font-family: var(--ff-title);
+                font-weight: 600;
+                color: var(--c-text-primary);
+                margin-bottom: calc(10px * var(--margin-scale));
+        }
+
+        &__links {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+        }
+
+        &__link {
+                display: block;
+                padding: calc(4px * var(--padding-scale)) 0;
+                color: var(--c-text-body-secondary);
+                text-decoration: none;
+                font-size: var(--font-size);
+                transition: color var(--transition);
+
+                &:hover {
+                        color: var(--c-primary-hover);
+                }
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .mega-menu__list {
+                flex-direction: column;
+        }
+
+        .mega-menu__item--open .mega-menu__content {
+                position: static;
+        }
+
+        .mega-menu__content {
+                box-shadow: none;
+                padding: calc(10px * var(--padding-scale));
+        }
+}
+

--- a/template/sections/navigation/mega-menu/mega-menu.html
+++ b/template/sections/navigation/mega-menu/mega-menu.html
@@ -1,0 +1,27 @@
+<nav class="mega-menu">
+        <ul class="mega-menu__list">
+                {% for item in section.items %}
+                <li class="mega-menu__item">
+                        <a href="{{{item.url}}}" class="mega-menu__toggle">{{{item.title}}}</a>
+                        {% if item.columns %}
+                        <div class="mega-menu__content">
+                                {% for col in item.columns %}
+                                <div class="mega-menu__column">
+                                        {% if col.title %}
+                                        <div class="mega-menu__column-title">{{{col.title}}}</div>
+                                        {% endif %}
+                                        <ul class="mega-menu__links">
+                                                {% for link in col.links %}
+                                                <li>
+                                                        <a href="{{{link.url}}}" class="mega-menu__link">{{{link.title}}}</a>
+                                                </li>
+                                                {% endfor %}
+                                        </ul>
+                                </div>
+                                {% endfor %}
+                        </div>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+</nav>

--- a/template/sections/navigation/mega-menu/module.json
+++ b/template/sections/navigation/mega-menu/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-navigation-mega-menu.git" }

--- a/template/sections/navigation/mega-menu/readme.MD
+++ b/template/sections/navigation/mega-menu/readme.MD
@@ -1,0 +1,100 @@
+# 📂 Mega Menu `/sections/navigation/mega-menu`
+
+Responsive navigation component that reveals a multi-column panel on item click. Ideal for sites with many categories.
+
+## ✅ Features
+
+-   Top-level navigation items toggle expansive panels
+-   Supports multiple link columns with optional headings
+-   Mobile-friendly with stacked layout
+-   Uses CSS variables for theme-driven colors, spacing, and typography
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/navigation/mega-menu/mega-menu.html",
+        "items": [
+                {
+                        "title": "Products",
+                        "url": "/products",
+                        "columns": [
+                                {
+                                        "title": "Category",
+                                        "links": [
+                                                { "title": "Item", "url": "/item" }
+                                        ]
+                                }
+                        ]
+                }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<nav class="mega-menu">
+        <ul class="mega-menu__list">
+                {% for item in section.items %}
+                <li class="mega-menu__item">
+                        <a href="{{{item.url}}}" class="mega-menu__toggle">{{{item.title}}}</a>
+                        {% if item.columns %}
+                        <div class="mega-menu__content">
+                                {% for col in item.columns %}
+                                <div class="mega-menu__column">
+                                        {% if col.title %}
+                                        <div class="mega-menu__column-title">{{{col.title}}}</div>
+                                        {% endif %}
+                                        <ul class="mega-menu__links">
+                                                {% for link in col.links %}
+                                                <li>
+                                                        <a href="{{{link.url}}}" class="mega-menu__link">{{{link.title}}}</a>
+                                                </li>
+                                                {% endfor %}
+                                        </ul>
+                                </div>
+                                {% endfor %}
+                        </div>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ul>
+</nav>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Layout and gaps scale with `--margin-scale` and `--padding-scale`
+-   Panels use `--c-bg-item` and `--c-shadow` for background and shadow
+-   Typography driven by `--ff-base`, `--ff-title`, and `--font-size`
+-   Links transition color via `--transition` and `--c-primary-hover`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                | Description                             |
+| ----------------------- | --------------------------------------- |
+| `--ff-base`             | Base font family                        |
+| `--ff-title`            | Font for column titles                  |
+| `--c-body`              | Menu background                         |
+| `--c-bg-item`           | Panel background                        |
+| `--c-shadow`            | Panel shadow                            |
+| `--c-text-primary`      | Top-level item text color               |
+| `--c-text-body-secondary` | Link color                            |
+| `--c-primary-hover`     | Link hover color                        |
+| `--font-size`           | Base font size                          |
+| `--line-height`         | Line height                             |
+| `--padding-scale`       | Scales padding                          |
+| `--margin-scale`        | Scales gaps                             |
+| `--transition`          | Link hover transition                   |
+| `--bp-md`               | Responsive breakpoint for stacking      |
+
+---


### PR DESCRIPTION
## Summary
- add navigation mega menu section with styles and docs
- integrate mega menu styles into global stylesheet
- implement basic toggle logic for mega menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc5a571c833391cc64c3bae90b1a