### PR TITLE
feat: add breadcrumbs navigation section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,42 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.breadcrumbs {
+        font-family: var(--ff-base);
+        font-size: calc(var(--font-size) * 0.875);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        padding: calc(8px * var(--padding-scale)) 0;
+}
+.breadcrumbs__list {
+        display: flex;
+        flex-wrap: wrap;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+}
+.breadcrumbs__item {
+        display: flex;
+        align-items: center;
+}
+.breadcrumbs__item + .breadcrumbs__item::before {
+        content: "/";
+        margin: 0 calc(8px * var(--margin-scale));
+        color: var(--c-text-body-secondary);
+}
+.breadcrumbs__link {
+        color: var(--c-text-secondary);
+        text-decoration: none;
+        transition: color var(--transition);
+}
+.breadcrumbs__link:hover {
+        color: var(--c-text-primary);
+}
+.breadcrumbs__current {
+        color: var(--c-text-primary);
+}
+@media screen and (max-width: var(--bp-sm)) {
+        .breadcrumbs {
+                font-size: calc(var(--font-size) * 0.75);
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/navigation/breadcrumbs/breadcrumbs";

--- a/template/sections/navigation/breadcrumbs/LICENSE
+++ b/template/sections/navigation/breadcrumbs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/navigation/breadcrumbs/_breadcrumbs.scss
+++ b/template/sections/navigation/breadcrumbs/_breadcrumbs.scss
@@ -1,0 +1,49 @@
+// breadcrumbs navigation section
+
+.breadcrumbs {
+        font-family: var(--ff-base);
+        font-size: calc(var(--font-size) * 0.875);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        padding: calc(8px * var(--padding-scale)) 0;
+
+        &__list {
+                display: flex;
+                flex-wrap: wrap;
+                list-style: none;
+                margin: 0;
+                padding: 0;
+        }
+
+        &__item {
+                display: flex;
+                align-items: center;
+        }
+
+        &__item + &__item::before {
+                content: "/";
+                margin: 0 calc(8px * var(--margin-scale));
+                color: var(--c-text-body-secondary);
+        }
+
+        &__link {
+                color: var(--c-text-secondary);
+                text-decoration: none;
+                transition: color var(--transition);
+
+                &:hover {
+                        color: var(--c-text-primary);
+                }
+        }
+
+        &__current {
+                color: var(--c-text-primary);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .breadcrumbs {
+                font-size: calc(var(--font-size) * 0.75);
+        }
+}
+

--- a/template/sections/navigation/breadcrumbs/breadcrumbs.html
+++ b/template/sections/navigation/breadcrumbs/breadcrumbs.html
@@ -1,0 +1,15 @@
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+        {% if section.items %}
+        <ol class="breadcrumbs__list">
+                {% for item in section.items %}
+                <li class="breadcrumbs__item">
+                        {% if not loop.last %}
+                        <a href="{{{item.url}}}" class="breadcrumbs__link">{{{item.label}}}</a>
+                        {% else %}
+                        <span class="breadcrumbs__current">{{{item.label}}}</span>
+                        {% endif %}
+                </li>
+                {% endfor %}
+        </ol>
+        {% endif %}
+</nav>

--- a/template/sections/navigation/breadcrumbs/module.json
+++ b/template/sections/navigation/breadcrumbs/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-navigation-breadcrumbs.git" }

--- a/template/sections/navigation/breadcrumbs/readme.MD
+++ b/template/sections/navigation/breadcrumbs/readme.MD
@@ -1,0 +1,70 @@
+# 📂 Breadcrumbs `/sections/navigation/breadcrumbs`
+
+A simple breadcrumb navigation component for indicating the current page's location within a hierarchy.
+
+## ✅ Features
+
+-   Accessible `<nav aria-label="Breadcrumb">` container
+-   Supports any number of breadcrumb items
+-   Last item rendered as the current location without a link
+-   Uses CSS variables for typography, spacing, colors, and responsiveness
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure:
+
+```json
+{
+        "src": "/sections/navigation/breadcrumbs/breadcrumbs.html",
+        "items": [
+                { "label": "Home", "url": "/" },
+                { "label": "Docs", "url": "/docs" },
+                { "label": "API" }
+        ]
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+                <li class="breadcrumbs__item">
+                        <a href="{{{item.url}}}" class="breadcrumbs__link">{{{item.label}}}</a>
+                </li>
+                <li class="breadcrumbs__item">
+                        <span class="breadcrumbs__current">{{{item.label}}}</span>
+                </li>
+        </ol>
+</nav>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Spacing scales via `--padding-scale` and `--margin-scale`
+-   Typography uses `--font-size`, `--line-height`, `--letter-spacing`, and `--ff-base`
+-   Link and current item colors use `--c-text-secondary`, `--c-text-primary`, and `--c-text-body-secondary`
+-   Hover effects transition with `--transition`
+-   Font size adjusts at the `--bp-sm` breakpoint
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                  | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--padding-scale`         | Vertical padding around breadcrumb bar          |
+| `--margin-scale`          | Space around separators                          |
+| `--font-size`             | Base font size                                   |
+| `--line-height`           | Line height                                      |
+| `--letter-spacing`        | Letter spacing                                   |
+| `--ff-base`               | Font family                                      |
+| `--c-text-secondary`      | Link text color                                  |
+| `--c-text-primary`        | Current item and hover text color                |
+| `--c-text-body-secondary` | Separator color                                  |
+| `--transition`            | Transition for hover states                      |
+| `--bp-sm`                 | Breakpoint for responsive font size adjustments  |


### PR DESCRIPTION
## Summary
- add navigation breadcrumbs section with SCSS, HTML, and docs
- import breadcrumbs styles into global stylesheet

## Testing
- `npx sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc13ed2c8333b81e3647322f3391