### PR TITLE
feat: add image caption media section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,31 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.image-caption {
+        text-align: center;
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+}
+.image-caption__img {
+        width: 100%;
+        display: block;
+        border-radius: var(--b-radius);
+}
+.image-caption__caption {
+        margin-top: calc(8px * var(--margin-scale));
+        font-size: calc(var(--font-size) * 0.9);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-body-secondary);
+        transition: color var(--transition);
+}
+@media screen and (max-width: var(--bp-md)) {
+        .image-caption__caption {
+                font-size: calc(var(--font-size) * 0.85);
+        }
+}
+@media screen and (max-width: var(--bp-sm)) {
+        .image-caption__caption {
+                font-size: calc(var(--font-size) * 0.8);
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/media/image-caption/image-caption";

--- a/template/sections/media/image-caption/LICENSE
+++ b/template/sections/media/image-caption/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/media/image-caption/_image-caption.scss
+++ b/template/sections/media/image-caption/_image-caption.scss
@@ -1,0 +1,34 @@
+// image-caption section
+
+.image-caption {
+        text-align: center;
+        padding-bottom: calc(50px * var(--padding-scale));
+        font-family: var(--ff-base);
+
+        &__img {
+                width: 100%;
+                display: block;
+                border-radius: var(--b-radius);
+        }
+
+        &__caption {
+                margin-top: calc(8px * var(--margin-scale));
+                font-size: calc(var(--font-size) * 0.9);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                transition: color var(--transition);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .image-caption__caption {
+                font-size: calc(var(--font-size) * 0.85);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .image-caption__caption {
+                font-size: calc(var(--font-size) * 0.8);
+        }
+}

--- a/template/sections/media/image-caption/image-caption.html
+++ b/template/sections/media/image-caption/image-caption.html
@@ -1,0 +1,6 @@
+<figure class="image-caption">
+        <img class="image-caption__img" src="{{{section.img}}}" alt="" />
+        {% if section.caption %}
+        <figcaption class="image-caption__caption">{{{section.caption}}}</figcaption>
+        {% endif %}
+</figure>

--- a/template/sections/media/image-caption/module.json
+++ b/template/sections/media/image-caption/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-media-image-caption.git" }

--- a/template/sections/media/image-caption/readme.MD
+++ b/template/sections/media/image-caption/readme.MD
@@ -1,0 +1,59 @@
+# 📂 Image Caption `/sections/media/image-caption`
+
+Display a single image with an optional caption. Perfect for highlighting photos, illustrations, or screenshots with supporting text.
+
+## ✅ Features
+
+-   Optional caption rendered via `<figcaption>`
+-   Responsive image that uses global design tokens
+-   Typography and spacing adapt across breakpoints
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/media/image-caption/image-caption.html",
+        "img": "/img/example.jpg",
+        "caption": "Optional caption text"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<figure class="image-caption">
+        <img class="image-caption__img" src="{{{section.img}}}" alt="" />
+        {% if section.caption %}
+        <figcaption class="image-caption__caption">{{{section.caption}}}</figcaption>
+        {% endif %}
+</figure>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Root figure centers content and adds scalable bottom padding
+-   Caption text leverages global font sizing and color variables
+-   Responsive font sizing adjusts at `--bp-md` and `--bp-sm`
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                       |
+| ------------------------------- | ------------------------------------------------- |
+| `--padding-scale`               | Controls bottom spacing                           |
+| `--margin-scale`                | Spacing above caption                             |
+| `--font-size`                   | Base font size for caption                        |
+| `--line-height`                 | Caption line height                               |
+| `--letter-spacing`              | Caption letter spacing                            |
+| `--ff-base`                     | Font family for caption text                      |
+| `--b-radius`                    | Rounds image corners                              |
+| `--c-text-body-secondary`       | Caption text color                                |
+| `--transition`                  | Color transition for caption text                 |
+| `--bp-md`, `--bp-sm`            | Breakpoints for responsive caption size           |


### PR DESCRIPTION
## Summary
- add media image-caption section with optional caption support
- style section using global CSS variables
- document usage and theme variables

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_6896fbb52b5483339188f44069c5141d