### PR TITLE
feat: add audio player section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,64 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.audio-player {
+        padding-bottom: calc(50px * var(--padding-scale));
+        text-align: center;
+        font-family: var(--ff-base);
+}
+.audio-player__audio {
+        width: 100%;
+        max-width: 600px;
+        display: block;
+        margin: 0 auto;
+        border-radius: var(--b-radius);
+        outline: none;
+}
+.audio-player__title {
+        font-family: var(--ff-title);
+        font-size: 32px;
+        font-weight: 600;
+        padding-top: calc(12px * var(--padding-scale));
+        text-transform: uppercase;
+        letter-spacing: var(--letter-spacing);
+        line-height: var(--line-height);
+        color: var(--c-text-primary);
+}
+.audio-player__description {
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        color: var(--c-text-body-secondary);
+        margin-top: calc(12px * var(--margin-scale));
+        max-width: 70ch;
+        margin-left: auto;
+        margin-right: auto;
+        transition: color var(--transition);
+}
+@media screen and (max-width: var(--bp-lg)) {
+        .audio-player__title {
+                font-size: 28px;
+        }
+        .audio-player__description {
+                font-size: calc(var(--font-size) * 0.95);
+        }
+}
+@media screen and (max-width: var(--bp-md)) {
+        .audio-player__title {
+                font-size: 24px;
+        }
+        .audio-player__audio {
+                max-width: 100%;
+        }
+        .audio-player__description {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+@media screen and (max-width: var(--bp-sm)) {
+        .audio-player__title {
+                font-size: 20px;
+        }
+        .audio-player__description {
+                font-size: calc(var(--font-size) * 0.875);
+        }
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/media/audio-player/audio-player";

--- a/template/sections/media/audio-player/LICENSE
+++ b/template/sections/media/audio-player/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/media/audio-player/_audio-player.scss
+++ b/template/sections/media/audio-player/_audio-player.scss
@@ -1,0 +1,69 @@
+// audio-player section
+
+.audio-player {
+        padding-bottom: calc(50px * var(--padding-scale));
+        text-align: center;
+        font-family: var(--ff-base);
+
+        &__audio {
+                width: 100%;
+                max-width: 600px;
+                display: block;
+                margin: 0 auto;
+                border-radius: var(--b-radius);
+                outline: none;
+        }
+
+        &__title {
+                font-family: var(--ff-title);
+                font-size: 32px;
+                font-weight: 600;
+                padding-top: calc(12px * var(--padding-scale));
+                text-transform: uppercase;
+                letter-spacing: var(--letter-spacing);
+                line-height: var(--line-height);
+                color: var(--c-text-primary);
+        }
+
+        &__description {
+                font-size: var(--font-size);
+                line-height: var(--line-height);
+                letter-spacing: var(--letter-spacing);
+                color: var(--c-text-body-secondary);
+                margin-top: calc(12px * var(--margin-scale));
+                max-width: 70ch;
+                margin-left: auto;
+                margin-right: auto;
+                transition: color var(--transition);
+        }
+}
+
+@media screen and (max-width: var(--bp-lg)) {
+        .audio-player__title {
+                font-size: 28px;
+        }
+        .audio-player__description {
+                font-size: calc(var(--font-size) * 0.95);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .audio-player__title {
+                font-size: 24px;
+        }
+        .audio-player__audio {
+                max-width: 100%;
+        }
+        .audio-player__description {
+                font-size: calc(var(--font-size) * 0.9);
+        }
+}
+
+@media screen and (max-width: var(--bp-sm)) {
+        .audio-player__title {
+                font-size: 20px;
+        }
+        .audio-player__description {
+                font-size: calc(var(--font-size) * 0.875);
+        }
+}

--- a/template/sections/media/audio-player/audio-player.html
+++ b/template/sections/media/audio-player/audio-player.html
@@ -1,0 +1,18 @@
+<div class="audio-player">
+        <audio
+                class="audio-player__audio"
+                controls
+                {% if section.autoplay %}autoplay{% endif %}
+                {% if section.loop %}loop{% endif %}
+        >
+                <source src="{{{section.audio}}}" />
+                Your browser does not support the audio element.
+        </audio>
+
+        {% if section.title %}
+        <div class="audio-player__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="audio-player__description">{{{section.description}}}</div>
+        {% endif %}
+</div>

--- a/template/sections/media/audio-player/module.json
+++ b/template/sections/media/audio-player/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-media-audio-player.git" }

--- a/template/sections/media/audio-player/readme.MD
+++ b/template/sections/media/audio-player/readme.MD
@@ -1,0 +1,80 @@
+# 📂 Audio Player `/sections/media/audio-player`
+
+Audio player section that embeds an HTML5 audio element with optional title and description. Useful for podcasts, music samples, or any inline audio content.
+
+## ✅ Features
+
+-   Plays audio from a provided source
+-   Optional title and description (conditionally rendered)
+-   Uses native HTML5 controls
+-   Responsive layout leveraging CSS variables
+-   Centralized theming via global design tokens
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via section
+
+```json
+{
+        "src": "/sections/media/audio-player/audio-player.html",
+        "audio": "/audio/sample.mp3",
+        "title": "Optional audio title",
+        "description": "Optional supporting text",
+        "autoplay": false,
+        "loop": false
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div class="audio-player">
+        <audio
+                class="audio-player__audio"
+                controls
+                {% if section.autoplay %}autoplay{% endif %}
+                {% if section.loop %}loop{% endif %}
+        >
+                <source src="{{{section.audio}}}" />
+                Your browser does not support the audio element.
+        </audio>
+
+        {% if section.title %}
+        <div class="audio-player__title">{{{section.title}}}</div>
+        {% endif %}
+        {% if section.description %}
+        <div class="audio-player__description">{{{section.description}}}</div>
+        {% endif %}
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Audio element is centered with `max-width` and rounded corners
+-   Typography and spacing scale via `--font-size`, `--padding-scale`, and `--margin-scale`
+-   Title and description colors inherit from theme variables
+-   Responsive adjustments at defined breakpoints
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable                        | Description                                        |
+| ------------------------------- | -------------------------------------------------- |
+| `--padding-scale`               | Scales padding values in section                   |
+| `--margin-scale`                | Controls margin spacing                            |
+| `--font-size`                   | Base font size for description                     |
+| `--line-height`                 | Line height for title and description              |
+| `--letter-spacing`              | Applied to title and description                   |
+| `--b-radius`                    | Rounds the audio element                           |
+| `--ff-base`                     | Font for description text                          |
+| `--ff-title`                    | Font for title text                                |
+| `--c-text-primary`              | Title text color                                   |
+| `--c-text-body-secondary`       | Description text color                             |
+| `--bp-lg`, `--bp-md`, `--bp-sm` | Used in media queries to adjust sizes responsively |
+
+---


### PR DESCRIPTION
## Summary
- add dedicated audio player section with HTML, SCSS, and docs
- include audio player styles in global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fb770b308333932ecd25fee919e8