### PR TITLE
feat: add tabs layout section

### DIFF
--- a/template/css/index.css
+++ b/template/css/index.css
@@ -4507,3 +4507,36 @@ ul {
 		margin-top: calc(8px * var(--margin-scale));
 	}
 }
+.tabs {
+        font-family: var(--ff-base);
+}
+.tabs__nav {
+        display: flex;
+        border-bottom: 2px solid var(--c-border);
+}
+.tabs__nav-button {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: calc(10px * var(--padding-scale)) calc(20px * var(--padding-scale));
+        font-size: var(--font-size);
+        color: var(--c-text-primary);
+        border-bottom: 2px solid transparent;
+        transition: color var(--transition), border-color var(--transition);
+}
+.tabs__nav-button.active {
+        border-color: var(--c-primary);
+        color: var(--c-primary);
+}
+.tabs__nav-button:hover {
+        color: var(--c-primary-hover);
+}
+.tabs__content {
+        padding-top: calc(20px * var(--padding-scale));
+}
+.tabs__pane {
+        display: none;
+}
+.tabs__pane.active {
+        display: block;
+}

--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/layout/tabs/tabs";

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -210,3 +210,22 @@ document.addEventListener("DOMContentLoaded", () => {
 		});
 	});
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll(".tabs").forEach((tabs) => {
+                const buttons = tabs.querySelectorAll(".tabs__nav-button");
+                const panes = tabs.querySelectorAll(".tabs__pane");
+
+                buttons.forEach((button, index) => {
+                        button.addEventListener("click", () => {
+                                buttons.forEach((b) => b.classList.remove("active"));
+                                panes.forEach((p) => p.classList.remove("active"));
+                                button.classList.add("active");
+                                const pane = panes[index];
+                                if (pane) {
+                                        pane.classList.add("active");
+                                }
+                        });
+                });
+        });
+});

--- a/template/sections/layout/tabs/LICENSE
+++ b/template/sections/layout/tabs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/layout/tabs/_tabs.scss
+++ b/template/sections/layout/tabs/_tabs.scss
@@ -1,0 +1,44 @@
+// tabs section
+
+.tabs {
+        font-family: var(--ff-base);
+
+        &__nav {
+                display: flex;
+                border-bottom: 2px solid var(--c-border);
+        }
+
+        &__nav-button {
+                background: none;
+                border: none;
+                cursor: pointer;
+                padding: calc(10px * var(--padding-scale))
+                        calc(20px * var(--padding-scale));
+                font-size: var(--font-size);
+                color: var(--c-text-primary);
+                border-bottom: 2px solid transparent;
+                transition: color var(--transition),
+                        border-color var(--transition);
+
+                &.active {
+                        border-color: var(--c-primary);
+                        color: var(--c-primary);
+                }
+
+                &:hover {
+                        color: var(--c-primary-hover);
+                }
+        }
+
+        &__content {
+                padding-top: calc(20px * var(--padding-scale));
+        }
+
+        &__pane {
+                display: none;
+
+                &.active {
+                        display: block;
+                }
+        }
+}

--- a/template/sections/layout/tabs/module.json
+++ b/template/sections/layout/tabs/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-layout-tabs.git" }

--- a/template/sections/layout/tabs/readme.MD
+++ b/template/sections/layout/tabs/readme.MD
@@ -1,0 +1,71 @@
+# \ud83d\udcc2 Tabs `/sections/layout/tabs`
+
+Tabbed interface with clickable navigation that toggles visibility of content panes.
+
+## \u2705 Features
+
+-   Horizontal tab navigation
+-   Active tab highlighted using theme colors
+-   Content panes switch without reloading
+-   Uses CSS variables for colors, spacing and typography
+
+---
+
+## \ud83d\uddfc Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/layout/tabs/tabs.html",
+        "tabs": [
+                { "label": "Tab 1", "content": "<p>First tab content</p>" },
+                { "label": "Tab 2", "content": "<p>Second tab content</p>" }
+        ]
+}
+```
+
+## \ud83e\uddf1 HTML Structure
+
+```html
+<div class="tabs">
+        <div class="tabs__nav">
+                {% for tab in section.tabs %}
+                <button class="tabs__nav-button{% if loop.index0 == 0 %} active{% endif %}" data-tab="{{ loop.index0 }}">{{{tab.label}}}</button>
+                {% endfor %}
+        </div>
+        <div class="tabs__content">
+                {% for tab in section.tabs %}
+                <div class="tabs__pane{% if loop.index0 == 0 %} active{% endif %}" data-pane="{{ loop.index0 }}">
+                        {{{tab.content}}}
+                </div>
+                {% endfor %}
+        </div>
+</div>
+```
+
+---
+
+## \ud83c\udf08 Styling Notes
+
+-   Navigation uses flexbox and `border-bottom`
+-   Active tab indicated by `--c-primary` color border
+-   Spacing scales with `--padding-scale`
+-   Font size derives from `--font-size`
+
+---
+
+## \ud83e\udde9 Theme Variables Used (from `template.json`)
+
+| Variable | Description |
+| --- | --- |
+| `--ff-base` | Base font for the component |
+| `--padding-scale` | Scales padding for tabs and content |
+| `--font-size` | Base font size for tab labels |
+| `--c-border` | Border color for navigation |
+| `--c-primary` | Color for active tab |
+| `--c-primary-hover` | Hover color for tabs |
+| `--c-text-primary` | Default tab text color |
+| `--transition` | Transition effect for color and border |
+
+---

--- a/template/sections/layout/tabs/tabs.html
+++ b/template/sections/layout/tabs/tabs.html
@@ -1,0 +1,14 @@
+<div class="tabs">
+        <div class="tabs__nav">
+                {% for tab in section.tabs %}
+                <button class="tabs__nav-button{% if loop.index0 == 0 %} active{% endif %}" data-tab="{{ loop.index0 }}">{{{tab.label}}}</button>
+                {% endfor %}
+        </div>
+        <div class="tabs__content">
+                {% for tab in section.tabs %}
+                <div class="tabs__pane{% if loop.index0 == 0 %} active{% endif %}" data-pane="{{ loop.index0 }}">
+                        {{{tab.content}}}
+                </div>
+                {% endfor %}
+        </div>
+</div>


### PR DESCRIPTION
## Summary
- add layout tabs section with HTML, SCSS, and docs
- wire tabs styles into global bundle
- implement JS for tab switching

## Testing
- `node --check template/js/index.js`
- `npx sass --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896fb3331348333a09868d1ff62fbfa