### PR TITLE
feat: add sticky layout section

### DIFF
--- a/template/css/index.scss
+++ b/template/css/index.scss
@@ -53,3 +53,4 @@
 @use "../sections/ecommerce/payment-logos/payment-logos";
 @use "../sections/ecommerce/discount-badge/discount-badge";
 @use "../sections/ecommerce/add-to-cart/add-to-cart";
+@use "../sections/layout/sticky/sticky";

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -210,3 +210,17 @@ document.addEventListener("DOMContentLoaded", () => {
 		});
 	});
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+        const sticks = document.querySelectorAll("[data-sticky]");
+        sticks.forEach((el) => {
+                const start = el.offsetTop;
+                window.addEventListener("scroll", () => {
+                        if (window.scrollY > start) {
+                                el.classList.add("sticky--stuck");
+                        } else {
+                                el.classList.remove("sticky--stuck");
+                        }
+                });
+        });
+});

--- a/template/sections/layout/sticky/LICENSE
+++ b/template/sections/layout/sticky/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Web Art Work
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/sections/layout/sticky/_sticky.scss
+++ b/template/sections/layout/sticky/_sticky.scss
@@ -1,0 +1,31 @@
+// sticky layout section
+
+.sticky {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        padding: calc(12px * var(--padding-scale));
+        background-color: var(--c-bg-item);
+        color: var(--c-text-primary);
+        font-family: var(--ff-base);
+        font-size: var(--font-size);
+        line-height: var(--line-height);
+        letter-spacing: var(--letter-spacing);
+        border-radius: var(--b-radius);
+        transition: background-color var(--transition), box-shadow var(--transition);
+
+        &__content {
+                width: 100%;
+        }
+
+        &--stuck {
+                background-color: var(--c-secondary);
+                box-shadow: 0 2px 4px var(--c-shadow);
+        }
+}
+
+@media screen and (max-width: var(--bp-md)) {
+        .sticky {
+                padding: calc(8px * var(--padding-scale));
+        }
+}

--- a/template/sections/layout/sticky/module.json
+++ b/template/sections/layout/sticky/module.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/WebArtWork/wjst-section-layout-sticky.git" }

--- a/template/sections/layout/sticky/readme.MD
+++ b/template/sections/layout/sticky/readme.MD
@@ -1,0 +1,59 @@
+# 📂 Sticky `/sections/layout/sticky`
+
+Sticky layout block that keeps its content pinned to the top of the viewport while scrolling. Useful for persistent headers, sidebars or callouts.
+
+## ✅ Features
+
+-   Pure CSS `position: sticky` implementation
+-   Adds `.sticky--stuck` class when element is fixed to allow style changes
+-   Theming through global CSS variables for colors, spacing and typography
+
+---
+
+## 🧾 Section Data Schema
+
+This section expects the following data structure passed via `section`:
+
+```json
+{
+        "src": "/sections/layout/sticky/sticky.html",
+        "id": "mySticky",
+        "content": "Any HTML content that should remain visible while scrolling"
+}
+```
+
+## 🧱 HTML Structure
+
+```html
+<div id="{{{section.id}}}" class="sticky" data-sticky>
+        <div class="sticky__content">{{{section.content}}}</div>
+</div>
+```
+
+---
+
+## 🎨 Styling Notes
+
+-   Uses `top: 0` and `position: sticky` to pin the block
+-   `.sticky--stuck` class is toggled via JS when the block becomes fixed
+-   Responsive padding adjustment at medium breakpoint
+
+---
+
+## 🧩 Theme Variables Used (from `template.json`)
+
+| Variable            | Description                              |
+| ------------------- | ---------------------------------------- |
+| `--padding-scale`   | Scales padding values                     |
+| `--font-size`       | Base font size for content                |
+| `--line-height`     | Line height for content                   |
+| `--letter-spacing`  | Letter spacing for content                |
+| `--b-radius`        | Rounds sticky container                   |
+| `--c-bg-item`       | Background color of sticky block          |
+| `--c-secondary`     | Background color when stuck               |
+| `--c-text-primary`  | Text color                                |
+| `--c-shadow`        | Shadow used when stuck                    |
+| `--transition`      | Transition for background and shadow      |
+| `--bp-md`           | Breakpoint for mobile padding adjustments |
+
+---

--- a/template/sections/layout/sticky/sticky.html
+++ b/template/sections/layout/sticky/sticky.html
@@ -1,0 +1,5 @@
+<div id="{{{section.id}}}" class="sticky" data-sticky>
+        {% if section.content %}
+        <div class="sticky__content">{{{section.content}}}</div>
+        {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add layout sticky section with CSS variables and docs
- hook sticky styles into global build
- add scroll logic to toggle sticky class

## Testing
- `npx --yes sass template/css/index.scss template/css/index.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896f99f7b8c8333962f174ee90772dc