### PR TITLE
docs: add education sections guide

### DIFF
--- a/template/sections/education/readme.MD
+++ b/template/sections/education/readme.MD
@@ -1,0 +1,112 @@
+# 🎓 Education Sections – Manager Guide
+
+This guide explains how our education-related sections work together to build two primary page types:
+
+1. **Course Overview Page** – markets the course to prospective students.
+2. **Learning Page** – supports active students as they progress through a course.
+
+Unlike technical READMEs aimed at developers, this document focuses on **how a manager or content strategist** should use these sections and when each is appropriate.
+
+---
+
+## **1. Course Overview Page**
+
+**Purpose:**
+Gives potential students a clear picture of what the course offers, who teaches it, and how it compares to other options.
+
+**Sections commonly used:**
+
+| Section                                   | Why it’s here                                        | Manager tips |
+| ----------------------------------------- | ---------------------------------------------------- | ------------ |
+| **Instructor** (`education/instructor`)   | Introduces the teacher and builds credibility.       | Use real photos and concise bios. |
+| **Syllabus** (`education/syllabus`)       | Lists modules or topics covered in the course.       | Keep descriptions brief and actionable. |
+| **Timeline** (`education/timeline`)       | Shows key milestones or schedule.                    | Highlight major dates to set expectations. |
+| **Comparison Table** (`education/comparison-table`) | Compares plans, levels, or courses.           | Limit columns to the most relevant choices. |
+
+**Optional add-ons:**
+
+-   Include **Certificate** to demonstrate completion proof.
+-   Add a **Lesson List** preview if you want to show course depth.
+
+---
+
+## **2. Learning Page**
+
+**Purpose:**
+Provides enrolled students with tools to track progress, access lessons, and verify completion.
+
+**Sections commonly used:**
+
+| Section                                 | Why it’s here                                         | Manager tips |
+| --------------------------------------- | ----------------------------------------------------- | ------------ |
+| **Lesson List** (`education/lesson-list`) | Displays the sequence of lessons.                     | Clearly mark completed lessons. |
+| **Progress** (`education/progress`)     | Shows how far a student has progressed.               | Encourage students by celebrating milestones. |
+| **Quiz** (`education/quiz`)             | Evaluates understanding of the material.              | Keep quizzes short and provide feedback. |
+| **Certificate** (`education/certificate`) | Awards completion at the end of the course.         | Use branding and shareable formats. |
+
+**Optional add-ons:**
+
+-   Use **Timeline** to show upcoming deadlines.
+-   Include **Instructor** details for quick reference.
+
+---
+
+## **Section-by-Section Manager Summary**
+
+### **Certificate**
+Provides a visual certificate to confirm course completion.
+**Use on:** Learning pages or completion screens.
+**Frequency:** When offering proof of completion.
+
+### **Comparison Table**
+Side-by-side comparison of plans, levels, or courses.
+**Use on:** Course overview pages.
+**Frequency:** When multiple offerings exist.
+
+### **Instructor**
+Highlights the teacher with photo, name, and bio.
+**Use on:** Course overview and learning pages.
+**Frequency:** Always, to build trust.
+
+### **Lesson List**
+Ordered list of lessons or modules in a course.
+**Use on:** Learning pages.
+**Frequency:** Always for structured courses.
+
+### **Progress**
+Visual indicator of a student’s progress.
+**Use on:** Learning pages.
+**Frequency:** Always to keep students motivated.
+
+### **Quiz**
+Interactive quiz component to test knowledge.
+**Use on:** Learning pages.
+**Frequency:** Optional, based on course design.
+
+### **Syllabus**
+Outline of topics and objectives for the course.
+**Use on:** Course overview pages.
+**Frequency:** Always for transparency.
+
+### **Timeline**
+Shows key dates or stages in the course.
+**Use on:** Course overview or learning pages.
+**Frequency:** When timing matters.
+
+---
+
+## **Putting It Together**
+
+### **Course Overview Page**
+
+-   Instructor
+-   Syllabus
+-   Timeline
+-   Comparison Table (if multiple options)
+
+### **Learning Page**
+
+-   Lesson List
+-   Progress
+-   Quiz (optional)
+-   Certificate (upon completion)


### PR DESCRIPTION
## Summary
- add manager-focused documentation for education sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b47b4ad7c8333b4fabf6dd0c04ced